### PR TITLE
[Feat/17] JPA 엔티티 생성: 채팅, 매너평가, 알림, 친구

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,14 +35,14 @@ repositories {
 }
 
 dependencies {
-	//implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	//implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.11'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	compileOnly 'org.projectlombok:lombok'
-	//runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/gamegoo/domain/Friend.java
+++ b/src/main/java/com/gamegoo/domain/Friend.java
@@ -1,0 +1,24 @@
+package com.gamegoo.domain;
+
+import com.gamegoo.domain.common.BaseDateTimeEntity;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Friend extends BaseDateTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "friend_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private Boolean isFriend;
+
+    @Column(nullable = false)
+    private Boolean isLiked;
+}

--- a/src/main/java/com/gamegoo/domain/chat/Chat.java
+++ b/src/main/java/com/gamegoo/domain/chat/Chat.java
@@ -1,0 +1,22 @@
+package com.gamegoo.domain.chat;
+
+import com.gamegoo.domain.common.BaseDateTimeEntity;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Chat extends BaseDateTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_id")
+    private Long id;
+
+    @Column(nullable = false, length = 1000)
+    private String contents;
+
+}

--- a/src/main/java/com/gamegoo/domain/chat/Chatroom.java
+++ b/src/main/java/com/gamegoo/domain/chat/Chatroom.java
@@ -1,0 +1,26 @@
+package com.gamegoo.domain.chat;
+
+import com.gamegoo.domain.common.BaseDateTimeEntity;
+import com.gamegoo.domain.enums.ChatroomType;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Chatroom extends BaseDateTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chatroom_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(30)", nullable = false)
+    private ChatroomType chatroomType;
+
+    @Column(columnDefinition = "TEXT")
+    private String postUrl;
+}

--- a/src/main/java/com/gamegoo/domain/chat/MemberChatroom.java
+++ b/src/main/java/com/gamegoo/domain/chat/MemberChatroom.java
@@ -1,0 +1,26 @@
+package com.gamegoo.domain.chat;
+
+import com.gamegoo.domain.common.BaseDateTimeEntity;
+import com.gamegoo.domain.enums.ChatroomStatus;
+import lombok.*;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberChatroom extends BaseDateTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_chatroom_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(30)", nullable = false)
+    private ChatroomStatus chatroomStatus;
+
+    private LocalDateTime lastViewDateTime;
+}

--- a/src/main/java/com/gamegoo/domain/common/BaseDateTimeEntity.java
+++ b/src/main/java/com/gamegoo/domain/common/BaseDateTimeEntity.java
@@ -1,0 +1,24 @@
+package com.gamegoo.domain.common;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseDateTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/gamegoo/domain/enums/ChatroomStatus.java
+++ b/src/main/java/com/gamegoo/domain/enums/ChatroomStatus.java
@@ -1,0 +1,5 @@
+package com.gamegoo.domain.enums;
+
+public enum ChatroomStatus {
+    ACTIVE, INACTIVE
+}

--- a/src/main/java/com/gamegoo/domain/enums/ChatroomType.java
+++ b/src/main/java/com/gamegoo/domain/enums/ChatroomType.java
@@ -1,0 +1,5 @@
+package com.gamegoo.domain.enums;
+
+public enum ChatroomType {
+    FRIEND, MATCHED, POST
+}

--- a/src/main/java/com/gamegoo/domain/manner/MannerKeyword.java
+++ b/src/main/java/com/gamegoo/domain/manner/MannerKeyword.java
@@ -1,0 +1,25 @@
+package com.gamegoo.domain.manner;
+
+import com.gamegoo.domain.common.BaseDateTimeEntity;
+import lombok.*;
+import org.springframework.lang.Nullable;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MannerKeyword extends BaseDateTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "manner_keyword_id")
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String contents;
+
+    @Column(nullable = false)
+    private Boolean isPositive;
+}

--- a/src/main/java/com/gamegoo/domain/manner/MannerRating.java
+++ b/src/main/java/com/gamegoo/domain/manner/MannerRating.java
@@ -1,0 +1,18 @@
+package com.gamegoo.domain.manner;
+
+import com.gamegoo.domain.common.BaseDateTimeEntity;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MannerRating extends BaseDateTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "manner_rating_id")
+    private Long id;
+}

--- a/src/main/java/com/gamegoo/domain/manner/MannerRatingKeyword.java
+++ b/src/main/java/com/gamegoo/domain/manner/MannerRatingKeyword.java
@@ -1,0 +1,19 @@
+package com.gamegoo.domain.manner;
+
+import com.gamegoo.domain.common.BaseDateTimeEntity;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MannerRatingKeyword extends BaseDateTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "manner_rating_keyword_id")
+    private Long id;
+
+}

--- a/src/main/java/com/gamegoo/domain/notification/Notification.java
+++ b/src/main/java/com/gamegoo/domain/notification/Notification.java
@@ -1,0 +1,24 @@
+package com.gamegoo.domain.notification;
+
+import com.gamegoo.domain.common.BaseDateTimeEntity;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Notification extends BaseDateTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @Column(nullable = false, length = 500)
+    private String content;
+
+    @Column(nullable = false)
+    private Boolean isRead;
+}

--- a/src/main/java/com/gamegoo/domain/notification/NotificationType.java
+++ b/src/main/java/com/gamegoo/domain/notification/NotificationType.java
@@ -1,0 +1,29 @@
+package com.gamegoo.domain.notification;
+
+import com.gamegoo.domain.common.BaseDateTimeEntity;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class NotificationType extends BaseDateTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_type_id")
+    private Long id;
+
+    @Column(nullable = false, length = 30)
+    private String name;
+
+    @Column(nullable = false, length = 400)
+    private String content;
+
+    @Column(nullable = false, length = 200)
+    private String imgUrl;
+
+
+}


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
채팅, 매너평가, 알림, 친구 도메인에 대한 JPA 엔티티 생성

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 도메인에 대한 JPA 엔티티 생성
- 생성일자, 수정일자를 위한 BaseTimeEntity 생성
- build.gradle 의존성 추가

## ⏳ 작업 내용
- [x] JPA 엔티티 기본 칼럼 설정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
