### PR TITLE
[Feat/29] JPA Entity 매핑 수정 

### DIFF
--- a/src/main/java/com/gamegoo/domain/Board.java
+++ b/src/main/java/com/gamegoo/domain/Board.java
@@ -34,7 +34,7 @@ public class Board extends BaseDateTimeEntity {
     @Column(name = "voice", nullable = false)
     private Boolean voice;
 
-    @Column(name = "content", nullable = false, length = 3000)
+    @Column(name = "content", nullable = false, length = 5000)
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/gamegoo/domain/Board.java
+++ b/src/main/java/com/gamegoo/domain/Board.java
@@ -1,9 +1,9 @@
 package com.gamegoo.domain;
 
+import com.gamegoo.domain.common.BaseDateTimeEntity;
 import lombok.*;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "Board")
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Board {
+public class Board extends BaseDateTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -36,12 +36,6 @@ public class Board {
 
     @Column(name = "content", nullable = false, length = 3000)
     private String content;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/com/gamegoo/domain/Board.java
+++ b/src/main/java/com/gamegoo/domain/Board.java
@@ -1,7 +1,6 @@
 package com.gamegoo.domain;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -10,6 +9,9 @@ import java.time.LocalDateTime;
 @Table(name = "Board")
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Board {
 
     @Id

--- a/src/main/java/com/gamegoo/domain/Member.java
+++ b/src/main/java/com/gamegoo/domain/Member.java
@@ -25,13 +25,13 @@ public class Member extends BaseDateTimeEntity {
     @Column(name = "member_id")
     private Long id;
 
-    @Column(name = "email", nullable = false, length = 30)
+    @Column(name = "email", nullable = false, length = 100)
     private String email;
 
-    @Column(name = "password", nullable = false, length = 50)
+    @Column(name = "password", nullable = false, length = 500)
     private String password;
 
-    @Column(name = "profile_image", length = 10)
+    @Column(name = "profile_image", length = 30)
     private String profileImage;
 
     @Column(name = "manner_level")
@@ -40,10 +40,10 @@ public class Member extends BaseDateTimeEntity {
     @Column(name = "blind", nullable = false)
     private Boolean blind = false;
 
-    @Column(name = "login_type", nullable = false, length = 30)
+    @Column(name = "login_type", nullable = false, length = 50)
     private String loginType = "General";
 
-    @Column(name = "gameuser_name", nullable = true, length = 30)
+    @Column(name = "gameuser_name", nullable = true, length = 100)
     private String gameuserName;
 
     @Column(name = "tier", nullable = false)

--- a/src/main/java/com/gamegoo/domain/Member.java
+++ b/src/main/java/com/gamegoo/domain/Member.java
@@ -50,7 +50,7 @@ public class Member extends BaseDateTimeEntity {
     private Integer tier;
 
     @Column(name = "winrate", nullable = false)
-    private Integer winRate;
+    private double winRate;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Board> boardList = new ArrayList<>();

--- a/src/main/java/com/gamegoo/domain/Member.java
+++ b/src/main/java/com/gamegoo/domain/Member.java
@@ -1,13 +1,13 @@
 package com.gamegoo.domain;
 
 import com.gamegoo.domain.champion.MemberChampion;
+import com.gamegoo.domain.common.BaseDateTimeEntity;
 import com.gamegoo.domain.gamestyle.GameStyle;
 import com.gamegoo.domain.manner.MannerRating;
 import com.gamegoo.domain.notification.Notification;
 import lombok.*;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,7 +19,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Member {
+public class Member extends BaseDateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "member_id")
@@ -51,12 +51,6 @@ public class Member {
 
     @Column(name = "winrate", nullable = false)
     private Integer winRate;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Board> boardList = new ArrayList<>();

--- a/src/main/java/com/gamegoo/domain/Member.java
+++ b/src/main/java/com/gamegoo/domain/Member.java
@@ -4,8 +4,7 @@ import com.gamegoo.domain.champion.MemberChampion;
 import com.gamegoo.domain.gamestyle.GameStyle;
 import com.gamegoo.domain.manner.MannerRating;
 import com.gamegoo.domain.notification.Notification;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -17,6 +16,9 @@ import java.util.List;
 @Table(name = "Member")
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/com/gamegoo/domain/Member.java
+++ b/src/main/java/com/gamegoo/domain/Member.java
@@ -57,7 +57,7 @@ public class Member {
     private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
-    private List<Member> boardList = new ArrayList<>();
+    private List<Board> boardList = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<MemberChampion> memberChampionList = new ArrayList<>();

--- a/src/main/java/com/gamegoo/domain/Member.java
+++ b/src/main/java/com/gamegoo/domain/Member.java
@@ -2,6 +2,7 @@ package com.gamegoo.domain;
 
 import com.gamegoo.domain.champion.MemberChampion;
 import com.gamegoo.domain.common.BaseDateTimeEntity;
+import com.gamegoo.domain.enums.LoginType;
 import com.gamegoo.domain.gamestyle.GameStyle;
 import com.gamegoo.domain.manner.MannerRating;
 import com.gamegoo.domain.notification.Notification;
@@ -40,8 +41,9 @@ public class Member extends BaseDateTimeEntity {
     @Column(name = "blind", nullable = false)
     private Boolean blind = false;
 
-    @Column(name = "login_type", nullable = false, length = 50)
-    private String loginType = "General";
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(50)", nullable = false)
+    private LoginType loginType;
 
     @Column(name = "gameuser_name", nullable = true, length = 100)
     private String gameuserName;

--- a/src/main/java/com/gamegoo/domain/enums/LoginType.java
+++ b/src/main/java/com/gamegoo/domain/enums/LoginType.java
@@ -1,0 +1,5 @@
+package com.gamegoo.domain.enums;
+
+public enum LoginType {
+    KAKAO, NAVER, GOOGLE, GENERAL
+}

--- a/src/main/java/com/gamegoo/domain/gamestyle/GameStyle.java
+++ b/src/main/java/com/gamegoo/domain/gamestyle/GameStyle.java
@@ -1,8 +1,7 @@
 package com.gamegoo.domain.gamestyle;
 
 import com.gamegoo.domain.Member;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -11,6 +10,9 @@ import java.time.LocalDateTime;
 @Table(name = "GameStyle")
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class GameStyle {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/com/gamegoo/domain/gamestyle/GameStyle.java
+++ b/src/main/java/com/gamegoo/domain/gamestyle/GameStyle.java
@@ -1,10 +1,10 @@
 package com.gamegoo.domain.gamestyle;
 
 import com.gamegoo.domain.Member;
+import com.gamegoo.domain.common.BaseDateTimeEntity;
 import lombok.*;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "GameStyle")
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class GameStyle {
+public class GameStyle extends BaseDateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "gamestyle_id", nullable = false)
@@ -21,12 +21,6 @@ public class GameStyle {
 
     @Column(name = "style_name", nullable = false, length = 30)
     private String styleName;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/com/gamegoo/domain/gamestyle/GameStyle.java
+++ b/src/main/java/com/gamegoo/domain/gamestyle/GameStyle.java
@@ -1,5 +1,6 @@
 package com.gamegoo.domain.gamestyle;
 
+import com.gamegoo.domain.Member;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -24,5 +25,9 @@ public class GameStyle {
 
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
 }

--- a/src/main/java/com/gamegoo/domain/gamestyle/GameStyle.java
+++ b/src/main/java/com/gamegoo/domain/gamestyle/GameStyle.java
@@ -19,7 +19,7 @@ public class GameStyle extends BaseDateTimeEntity {
     @Column(name = "gamestyle_id", nullable = false)
     private Long id;
 
-    @Column(name = "style_name", nullable = false, length = 30)
+    @Column(name = "style_name", nullable = false, length = 100)
     private String styleName;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/gamegoo/domain/gamestyle/MemberGameStyle.java
+++ b/src/main/java/com/gamegoo/domain/gamestyle/MemberGameStyle.java
@@ -1,10 +1,10 @@
 package com.gamegoo.domain.gamestyle;
 
 import com.gamegoo.domain.Member;
+import com.gamegoo.domain.common.BaseDateTimeEntity;
 import lombok.*;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "MemberGameStyle")
@@ -13,19 +13,12 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class MemberGameStyle {
+public class MemberGameStyle extends BaseDateTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "member_gamestyle_id", nullable = false)
     private Long id;
-
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "gamestyle_id", nullable = false)

--- a/src/main/java/com/gamegoo/domain/gamestyle/MemberGameStyle.java
+++ b/src/main/java/com/gamegoo/domain/gamestyle/MemberGameStyle.java
@@ -1,8 +1,7 @@
 package com.gamegoo.domain.gamestyle;
 
 import com.gamegoo.domain.Member;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -11,6 +10,9 @@ import java.time.LocalDateTime;
 @Table(name = "MemberGameStyle")
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class MemberGameStyle {
 
     @Id

--- a/src/main/java/com/gamegoo/domain/manner/MannerRating.java
+++ b/src/main/java/com/gamegoo/domain/manner/MannerRating.java
@@ -19,7 +19,7 @@ public class MannerRating extends BaseDateTimeEntity {
     @Column(name = "manner_rating_id")
     private Long id;
 
-    @OneToMany(mappedBy = "mannerRatingKeyword", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "mannerRating", cascade = CascadeType.ALL)
     private List<MannerRatingKeyword> mannerRatingKeywordList = new ArrayList<>();
 
 

--- a/src/main/java/com/gamegoo/domain/manner/MannerRatingKeyword.java
+++ b/src/main/java/com/gamegoo/domain/manner/MannerRatingKeyword.java
@@ -13,7 +13,7 @@ import javax.persistence.*;
 public class MannerRatingKeyword extends BaseDateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(name = "manner_rating_keyword_id")
+    @Column(name = "manner_rating_keyword_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -21,7 +21,7 @@ public class MannerRatingKeyword extends BaseDateTimeEntity {
     private MannerRating mannerRating;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "manner_rating_keyword_id", nullable = false)
-    private MannerRatingKeyword mannerRatingKeyword;
+    @JoinColumn(name = "manner_keyword_id", nullable = false)
+    private MannerKeyword mannerKeyword;
 
 }


### PR DESCRIPTION
## 🚀 개요
JPA 엔티티 매핑 관련 수정

## 🔍 변경사항
- JPA 엔티티 관련 매핑 에러 수정
- JPA LoginType ENUM 추가

## ⏳ 작업 내용
- [ ] Member 테이블 매핑 수정
- [ ] GameStyle 테이블 매핑 수정
- [ ] RatingKeyword 테이블 매핑 수정
- [ ] - [x]  cicd 이벤트: pr merge됐을때만 돌도록, push x
- [ ]  builder 사용을 위한 어노테이션 3줄
- [ ]  BaseTimeEntity extend
- [ ]  Member loginType을 enum으로 변경
- [ ]  Member 승률 double로
- [ ]  password, email 길이 제한 수정
- [ ]  전체 length 조정

### 📝 논의사항
