### PR TITLE
[Feat/76] 채팅방 uuid 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
@@ -41,7 +41,8 @@ public enum ErrorStatus implements BaseErrorCode {
     POSITION_NOT_FOUND(HttpStatus.NOT_FOUND, "POSITION404", "해당 Position을 찾을 수 없습니다."),
 
     // Profile_Image 관련 에러
-    PROFILE_IMAGE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "PROFILE_IMAGE_400", "profile_image가 30자를 초과했습니다."),
+    PROFILE_IMAGE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "PROFILE_IMAGE_400",
+        "profile_image가 30자를 초과했습니다."),
 
     // Email 인증 관련 에러
     EMAIL_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL500", "이메일 전송 도중, 에러가 발생했습니다."),
@@ -51,11 +52,13 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // Riot 관련 에러
     RIOT_NOT_FOUND(HttpStatus.NOT_FOUND, "RIOT404", "해당 Riot 계정이 존재하지 않습니다."),
-    RIOT_MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "RIOTMATCH404", "해당 Riot 계정의 매칭을 불러오는 도중 에러가 발생했습니다."),
+    RIOT_MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "RIOTMATCH404",
+        "해당 Riot 계정의 매칭을 불러오는 도중 에러가 발생했습니다."),
     CHAMPION_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAMPION404", "해당 챔피언이 존재하지 않습니다."),
     RIOT_MEMBER_CONFLICT(HttpStatus.CONFLICT, "RIOT409", "해당 이메일 계정은 이미 다른 RIOT 계정과 연동되었습니다."),
     RIOT_ACCOUNT_CONFLICT(HttpStatus.CONFLICT, "RIOT409", "해당 RIOT 계정은 이미 다른 이메일과 연동되어있습니다."),
-    RIOT_INSUFFICIENT_MATCHES(HttpStatus.NOT_FOUND, "RIOT404", "해당 RIOT 계정은 최근 100판 이내에 솔로랭크, 자유랭크, 일반게임, 칼바람을 플레이한 적이 없기 때문에 선호하는 챔피언 3명을 정할 수 없습니다."),
+    RIOT_INSUFFICIENT_MATCHES(HttpStatus.NOT_FOUND, "RIOT404",
+        "해당 RIOT 계정은 최근 100판 이내에 솔로랭크, 자유랭크, 일반게임, 칼바람을 플레이한 적이 없기 때문에 선호하는 챔피언 3명을 정할 수 없습니다."),
     RIOT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "RIOT500", "RIOT API 연동 중 에러가 발생했습니다."),
 
     // 차단 관련 에러
@@ -68,13 +71,22 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_AND_TARGET_MEMBER_SAME(HttpStatus.BAD_REQUEST, "REPORT402", "회원과 신고 대상 회원이 같습니다."),
 
     // 게시판 글 작성 관련 에러
-    BOARD_GAME_STYLE_BAD_REQUEST(HttpStatus.BAD_REQUEST,"BOARD400", "게임 스타일 선택 개수(최대 3개)를 초과했습니다."),
+    BOARD_GAME_STYLE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "BOARD400",
+        "게임 스타일 선택 개수(최대 3개)를 초과했습니다."),
     GAME_MODE_INVALID(HttpStatus.BAD_REQUEST, "BOARD401", "게임모드 값은 1~4만 가능합니다."),
     MAIN_POSITION_INVALID(HttpStatus.BAD_REQUEST, "BOARD401", "주포지션 값은 1~5만 가능합니다."),
 
     SUB_POSITION_INVALID(HttpStatus.BAD_REQUEST, "BOARD401", "부포지션 값은 1~5만 가능합니다."),
 
-    WANT_POSITION_INVALID(HttpStatus.BAD_REQUEST, "BOARD401", "상대포지션 값은 1~5만 가능합니다.");
+    WANT_POSITION_INVALID(HttpStatus.BAD_REQUEST, "BOARD401", "상대포지션 값은 1~5만 가능합니다."),
+
+    // 채팅 관련 에러
+    CHAT_TARGET_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT4001", "채팅 대상 회원을 찾을 수 없습니다."),
+    CHATROOM_NOT_EXIST(HttpStatus.NOT_FOUND, "CHAT4002", "채팅방을 찾을 수 없습니다."),
+    CHATROOM_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "CHAT4003", "접근할 수 없는 채팅방 입니다."),
+    CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT4004", "해당 메시지를 찾을 수 없습니다"),
+
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;
@@ -83,19 +95,19 @@ public enum ErrorStatus implements BaseErrorCode {
     @Override
     public ErrorReasonDTO getReason() {
         return ErrorReasonDTO.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(false)
-                .build();
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .build();
     }
 
     @Override
     public ErrorReasonDTO getReasonHttpStatus() {
         return ErrorReasonDTO.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(false)
-                .httpStatus(httpStatus)
-                .build();
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .httpStatus(httpStatus)
+            .build();
     }
 }

--- a/src/main/java/com/gamegoo/apiPayload/exception/handler/ChatHandler.java
+++ b/src/main/java/com/gamegoo/apiPayload/exception/handler/ChatHandler.java
@@ -1,0 +1,11 @@
+package com.gamegoo.apiPayload.exception.handler;
+
+import com.gamegoo.apiPayload.code.BaseErrorCode;
+import com.gamegoo.apiPayload.exception.GeneralException;
+
+public class ChatHandler extends GeneralException {
+
+    public ChatHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/gamegoo/controller/chat/ChatController.java
+++ b/src/main/java/com/gamegoo/controller/chat/ChatController.java
@@ -1,14 +1,22 @@
 package com.gamegoo.controller.chat;
 
 import com.gamegoo.apiPayload.ApiResponse;
+import com.gamegoo.converter.ChatConverter;
+import com.gamegoo.domain.chat.Chatroom;
+import com.gamegoo.dto.chat.ChatRequest;
+import com.gamegoo.dto.chat.ChatResponse;
+import com.gamegoo.service.chat.ChatCommandService;
 import com.gamegoo.service.chat.ChatQueryService;
 import com.gamegoo.util.JWTUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,13 +28,25 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatController {
 
     private final ChatQueryService chatQueryService;
+    private final ChatCommandService chatCommandService;
 
     @Operation(summary = "채팅방 uuid 조회 API", description = "회원이 속한 채팅방의 uuid를 조회하는 API 입니다.")
     @GetMapping("/member/chatroom/uuid")
     public ApiResponse<List<String>> getChatroomUuid() {
-        Long memberId = JWTUtil.getCurrentUserId(); //헤더에 있는 jwt 토큰에서 id를 가져오는 코드
+        Long memberId = JWTUtil.getCurrentUserId();
         List<String> chatroomUuids = chatQueryService.getChatroomUuids(memberId);
         return ApiResponse.onSuccess(chatroomUuids);
+    }
+
+    @Operation(summary = "채팅방 생성 API", description = "채팅방을 생성하는 API 입니다.")
+    @PostMapping("/chatroom/create/test")
+    public ApiResponse<ChatResponse.ChatroomCreateResultDto> createChatroom(
+        @RequestBody @Valid ChatRequest.ChatroomCreateRequest request
+    ) {
+        Long memberId = JWTUtil.getCurrentUserId();
+        Chatroom chatroom = chatCommandService.createChatroom(request, memberId);
+        return ApiResponse.onSuccess(
+            ChatConverter.toChatroomCreateResultDto(chatroom, request.getTargetMemberId()));
     }
 
 }

--- a/src/main/java/com/gamegoo/controller/chat/ChatController.java
+++ b/src/main/java/com/gamegoo/controller/chat/ChatController.java
@@ -1,0 +1,32 @@
+package com.gamegoo.controller.chat;
+
+import com.gamegoo.apiPayload.ApiResponse;
+import com.gamegoo.service.chat.ChatQueryService;
+import com.gamegoo.util.JWTUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/v1")
+@Tag(name = "Chat", description = "Chat 관련 API")
+public class ChatController {
+
+    private final ChatQueryService chatQueryService;
+
+    @Operation(summary = "채팅방 uuid 조회 API", description = "회원이 속한 채팅방의 uuid를 조회하는 API 입니다.")
+    @GetMapping("/member/chatroom/uuid")
+    public ApiResponse<List<String>> getChatroomUuid() {
+        Long memberId = JWTUtil.getCurrentUserId(); //헤더에 있는 jwt 토큰에서 id를 가져오는 코드
+        List<String> chatroomUuids = chatQueryService.getChatroomUuids(memberId);
+        return ApiResponse.onSuccess(chatroomUuids);
+    }
+
+}

--- a/src/main/java/com/gamegoo/converter/ChatConverter.java
+++ b/src/main/java/com/gamegoo/converter/ChatConverter.java
@@ -1,0 +1,20 @@
+package com.gamegoo.converter;
+
+import com.gamegoo.domain.chat.Chatroom;
+import com.gamegoo.dto.chat.ChatResponse;
+
+public class ChatConverter {
+
+    public static ChatResponse.ChatroomCreateResultDto toChatroomCreateResultDto(Chatroom chatroom,
+        Long targetMemberId) {
+
+        return ChatResponse.ChatroomCreateResultDto.builder()
+            .chatroomId(chatroom.getId())
+            .chatroomType(chatroom.getChatroomType())
+            .uuid(chatroom.getUuid())
+            .postUrl(chatroom.getPostUrl())
+            .targetMemberId(targetMemberId)
+            .build();
+    }
+
+}

--- a/src/main/java/com/gamegoo/domain/Member.java
+++ b/src/main/java/com/gamegoo/domain/Member.java
@@ -2,17 +2,31 @@ package com.gamegoo.domain;
 
 import com.gamegoo.domain.board.Board;
 import com.gamegoo.domain.champion.MemberChampion;
+import com.gamegoo.domain.chat.MemberChatroom;
 import com.gamegoo.domain.common.BaseDateTimeEntity;
 import com.gamegoo.domain.enums.LoginType;
 import com.gamegoo.domain.gamestyle.MemberGameStyle;
 import com.gamegoo.domain.manner.MannerRating;
 import com.gamegoo.domain.notification.Notification;
 import com.gamegoo.domain.report.Report;
-import lombok.*;
-
-import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 
 @Entity
@@ -23,6 +37,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Member extends BaseDateTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
@@ -91,6 +106,9 @@ public class Member extends BaseDateTimeEntity {
 
     @OneToMany(mappedBy = "reporter", cascade = CascadeType.ALL)
     private List<Report> reportList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<MemberChatroom> memberChatroomList = new ArrayList<>();
 
 }
 

--- a/src/main/java/com/gamegoo/domain/chat/Chatroom.java
+++ b/src/main/java/com/gamegoo/domain/chat/Chatroom.java
@@ -2,9 +2,18 @@ package com.gamegoo.domain.chat;
 
 import com.gamegoo.domain.common.BaseDateTimeEntity;
 import com.gamegoo.domain.enums.ChatroomType;
-import lombok.*;
-
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -12,10 +21,13 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Chatroom extends BaseDateTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "chatroom_id")
     private Long id;
+
+    private String uuid;
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(30)", nullable = false)

--- a/src/main/java/com/gamegoo/domain/chat/Chatroom.java
+++ b/src/main/java/com/gamegoo/domain/chat/Chatroom.java
@@ -1,14 +1,18 @@
 package com.gamegoo.domain.chat;
 
+import com.gamegoo.domain.Member;
 import com.gamegoo.domain.common.BaseDateTimeEntity;
 import com.gamegoo.domain.enums.ChatroomType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,4 +39,8 @@ public class Chatroom extends BaseDateTimeEntity {
 
     @Column(columnDefinition = "TEXT")
     private String postUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "start_member_id")
+    private Member startMember;
 }

--- a/src/main/java/com/gamegoo/domain/chat/MemberChatroom.java
+++ b/src/main/java/com/gamegoo/domain/chat/MemberChatroom.java
@@ -40,4 +40,12 @@ public class MemberChatroom extends BaseDateTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chatroom_id", nullable = false)
     private Chatroom chatroom;
+
+    public void setMember(Member member) {
+        if (this.member != null) {
+            this.member.getMemberChatroomList().remove(this);
+        }
+        this.member = member;
+        this.member.getMemberChatroomList().add(this);
+    }
 }

--- a/src/main/java/com/gamegoo/domain/chat/MemberChatroom.java
+++ b/src/main/java/com/gamegoo/domain/chat/MemberChatroom.java
@@ -2,11 +2,20 @@ package com.gamegoo.domain.chat;
 
 import com.gamegoo.domain.Member;
 import com.gamegoo.domain.common.BaseDateTimeEntity;
-import com.gamegoo.domain.enums.ChatroomStatus;
-import lombok.*;
-
-import javax.persistence.*;
 import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -14,20 +23,19 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class MemberChatroom extends BaseDateTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_chatroom_id")
     private Long id;
 
-    @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "VARCHAR(30)", nullable = false)
-    private ChatroomStatus chatroomStatus;
+    private LocalDateTime lastViewDate;
 
-    private LocalDateTime lastViewDateTime;
+    private LocalDateTime lastJoinDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
-    private Member Member;
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chatroom_id", nullable = false)

--- a/src/main/java/com/gamegoo/domain/enums/ChatroomStatus.java
+++ b/src/main/java/com/gamegoo/domain/enums/ChatroomStatus.java
@@ -1,5 +1,0 @@
-package com.gamegoo.domain.enums;
-
-public enum ChatroomStatus {
-    ACTIVE, INACTIVE
-}

--- a/src/main/java/com/gamegoo/dto/chat/ChatRequest.java
+++ b/src/main/java/com/gamegoo/dto/chat/ChatRequest.java
@@ -1,0 +1,20 @@
+package com.gamegoo.dto.chat;
+
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+
+public class ChatRequest {
+
+    @Getter
+    public static class ChatroomCreateRequest {
+
+        @NotNull
+        Long targetMemberId;
+
+        @NotNull
+        String chatroomType;
+
+        String postUrl;
+    }
+
+}

--- a/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
+++ b/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
@@ -1,0 +1,24 @@
+package com.gamegoo.dto.chat;
+
+import com.gamegoo.domain.enums.ChatroomType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ChatResponse {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChatroomCreateResultDto {
+
+        Long chatroomId;
+        String uuid;
+        ChatroomType chatroomType;
+        String postUrl;
+        Long targetMemberId;
+    }
+
+}

--- a/src/main/java/com/gamegoo/repository/chat/ChatroomRepository.java
+++ b/src/main/java/com/gamegoo/repository/chat/ChatroomRepository.java
@@ -1,0 +1,14 @@
+package com.gamegoo.repository.chat;
+
+import com.gamegoo.domain.chat.Chatroom;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
+
+    @Query("SELECT c.uuid FROM MemberChatroom mc JOIN mc.chatroom c WHERE mc.member.id = :memberId AND mc.lastJoinDate IS NOT NULL")
+    List<String> findActiveChatroomUuidsByMemberId(@Param("memberId") Long memberId);
+
+}

--- a/src/main/java/com/gamegoo/repository/chat/MemberChatroomRepository.java
+++ b/src/main/java/com/gamegoo/repository/chat/MemberChatroomRepository.java
@@ -1,0 +1,8 @@
+package com.gamegoo.repository.chat;
+
+import com.gamegoo.domain.chat.MemberChatroom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberChatroomRepository extends JpaRepository<MemberChatroom, Long> {
+
+}

--- a/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
@@ -1,0 +1,83 @@
+package com.gamegoo.service.chat;
+
+import com.gamegoo.apiPayload.code.status.ErrorStatus;
+import com.gamegoo.apiPayload.exception.handler.ChatHandler;
+import com.gamegoo.domain.Member;
+import com.gamegoo.domain.chat.Chatroom;
+import com.gamegoo.domain.chat.MemberChatroom;
+import com.gamegoo.domain.enums.ChatroomType;
+import com.gamegoo.dto.chat.ChatRequest;
+import com.gamegoo.repository.chat.ChatroomRepository;
+import com.gamegoo.repository.chat.MemberChatroomRepository;
+import com.gamegoo.repository.member.MemberRepository;
+import com.gamegoo.service.member.ProfileService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatCommandService {
+
+    private final ProfileService profileService;
+    private final MemberRepository memberRepository;
+    private final MemberChatroomRepository memberChatroomRepository;
+    private final ChatroomRepository chatroomRepository;
+
+    /**
+     * 대상 회원과의 채팅방 생성
+     *
+     * @param request
+     * @param memberId
+     * @return
+     */
+    @Transactional
+    public Chatroom createChatroom(ChatRequest.ChatroomCreateRequest request, Long memberId) {
+        Member member = profileService.findMember(memberId);
+
+        // 채팅 대상 회원의 존재 여부 검증
+        Member targetMember = memberRepository.findById(request.getTargetMemberId())
+            .orElseThrow(() -> new ChatHandler(ErrorStatus.CHAT_TARGET_NOT_FOUND));
+
+        // chatroom 엔티티 생성
+        Chatroom chatroom = null;
+        String uuid = UUID.randomUUID().toString();
+        if (request.getChatroomType().equals(ChatroomType.FRIEND.toString())) { // 친구목록에서 시작된 채팅인 경우
+            chatroom = Chatroom.builder()
+                .uuid(uuid)
+                .chatroomType(ChatroomType.FRIEND)
+                .postUrl(null)
+                .startMember(null)
+                .build();
+        } else { // 특정 글을 보고 시작된 채팅인 경우
+            chatroom = Chatroom.builder()
+                .uuid(uuid)
+                .chatroomType(ChatroomType.POST)
+                .postUrl(request.getPostUrl())
+                .startMember(member)
+                .build();
+        }
+        Chatroom savedChatroom = chatroomRepository.save(chatroom);
+
+        // MemberChatroom 엔티티 생성 및 연관관계 매핑
+        // 나의 MemberChatroom 엔티티
+        MemberChatroom memberChatroom = MemberChatroom.builder()
+            .lastViewDate(null)
+            .chatroom(chatroom)
+            .build();
+        memberChatroom.setMember(member);
+        memberChatroomRepository.save(memberChatroom);
+
+        // 상대방의 MemberChatroom 엔티티
+        MemberChatroom targetMemberChatroom = MemberChatroom.builder()
+            .lastViewDate(null)
+            .chatroom(chatroom)
+            .build();
+        targetMemberChatroom.setMember(targetMember);
+        memberChatroomRepository.save(targetMemberChatroom);
+
+        return savedChatroom;
+    }
+
+}

--- a/src/main/java/com/gamegoo/service/chat/ChatQueryService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatQueryService.java
@@ -1,0 +1,28 @@
+package com.gamegoo.service.chat;
+
+import com.gamegoo.repository.chat.ChatroomRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatQueryService {
+
+    private final ChatroomRepository chatroomRepository;
+
+
+    /**
+     * 해당 회원의 ACTIVE한 채팅방의 uuid list를 리턴
+     *
+     * @param memberId
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public List<String> getChatroomUuids(Long memberId) {
+        return chatroomRepository.findActiveChatroomUuidsByMemberId(memberId);
+    }
+
+}


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
채팅방 uuid 목록 조회 API 구현 및 채팅 관련 엔티티 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 채팅방 uuid 목록 조회 API 구현
- 채팅방 생성 테스트용 API 구현
- member 엔티티에 memberChatroomList 연관관계 매핑 추가
- Chatroom 엔티티에 uuid, startMember 추가
- MemberChatroom 엔티티에 lastViewDate, lastJoinDate 추가, lastViewDateTime 삭제

## ⏳ 작업 내용
- [x] 채팅방 uuid 목록 조회 API 구현
- [x] 채팅방 생성 테스트용 API 구현
- [x] Member, Chatroom, MemberChatroom 엔티티 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
