### PR TITLE
[Feat/79] 친구 목록 조회 API 구현 및 엔티티 수정

### DIFF
--- a/src/main/java/com/gamegoo/controller/member/MemberController.java
+++ b/src/main/java/com/gamegoo/controller/member/MemberController.java
@@ -2,6 +2,7 @@ package com.gamegoo.controller.member;
 
 import com.gamegoo.apiPayload.ApiResponse;
 import com.gamegoo.converter.MemberConverter;
+import com.gamegoo.domain.Friend;
 import com.gamegoo.domain.Member;
 import com.gamegoo.dto.member.MemberResponse;
 import com.gamegoo.service.member.MemberService;
@@ -9,6 +10,8 @@ import com.gamegoo.util.JWTUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -60,5 +63,19 @@ public class MemberController {
         memberService.unBlockMember(memberId, targetMemberId);
 
         return ApiResponse.onSuccess("차단 해제 성공");
+    }
+
+    @Operation(summary = "친구 목록 조회 API", description = "해당 회원의 친구 목록을 조회하는 API 입니다.")
+    @GetMapping("/friends")
+    public ApiResponse<Object> getFriendList() {
+        Long memberId = JWTUtil.getCurrentUserId();
+        List<Friend> friends = memberService.getFriends(memberId);
+
+        List<MemberResponse.friendInfoDTO> friendInfoDTOList = friends.stream()
+            .map(MemberConverter::toFriendInfoDto).collect(
+                Collectors.toList());
+
+        return ApiResponse.onSuccess(friendInfoDTOList);
+
     }
 }

--- a/src/main/java/com/gamegoo/converter/MemberConverter.java
+++ b/src/main/java/com/gamegoo/converter/MemberConverter.java
@@ -1,54 +1,64 @@
 package com.gamegoo.converter;
 
+import com.gamegoo.domain.Friend;
 import com.gamegoo.domain.Member;
 import com.gamegoo.dto.member.MemberResponse;
-import org.springframework.data.domain.Page;
-
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
 
 public class MemberConverter {
 
     public static MemberResponse.blockListDTO toBlockListDTO(Page<Member> blockList) {
         List<MemberResponse.blockedMemberDTO> blockedMemberDtoList = blockList.stream()
-                .map(MemberConverter::toBlockedMemberDTO)
-                .collect(Collectors.toList());
+            .map(MemberConverter::toBlockedMemberDTO)
+            .collect(Collectors.toList());
 
         return MemberResponse.blockListDTO.builder()
-                .blocked_member_dto_list(blockedMemberDtoList)
-                .list_size(blockedMemberDtoList.size())
-                .total_page(blockList.getTotalPages())
-                .total_elements(blockList.getTotalElements())
-                .is_first(blockList.isFirst())
-                .is_last(blockList.isLast())
-                .build();
+            .blocked_member_dto_list(blockedMemberDtoList)
+            .list_size(blockedMemberDtoList.size())
+            .total_page(blockList.getTotalPages())
+            .total_elements(blockList.getTotalElements())
+            .is_first(blockList.isFirst())
+            .is_last(blockList.isLast())
+            .build();
     }
 
     public static MemberResponse.blockedMemberDTO toBlockedMemberDTO(Member membr) {
         return MemberResponse.blockedMemberDTO.builder()
-                .member_id(membr.getId())
-                .profile_img(membr.getProfileImage())
-                .email(membr.getEmail())
-                .name(membr.getGameName())
-                .build();
+            .member_id(membr.getId())
+            .profile_img(membr.getProfileImage())
+            .email(membr.getEmail())
+            .name(membr.getGameName())
+            .build();
     }
 
     public static MemberResponse.myProfileMemberDTO toMyProfileDTO(Member member) {
-        List<MemberResponse.GameStyleResponseDTO> dtoList = member.getMemberGameStyleList().stream().map(memberGameStyle -> MemberResponse.GameStyleResponseDTO.builder()
+        List<MemberResponse.GameStyleResponseDTO> dtoList = member.getMemberGameStyleList().stream()
+            .map(memberGameStyle -> MemberResponse.GameStyleResponseDTO.builder()
                 .gameStyleId(memberGameStyle.getGameStyle().getId())
                 .gameStyleName(memberGameStyle.getGameStyle().getStyleName())
                 .build()).collect(Collectors.toList());
 
         return MemberResponse.myProfileMemberDTO.builder()
-                .email(member.getEmail())
-                .gameName(member.getGameName())
-                .tag(member.getTag())
-                .tier(member.getTier())
-                .rank(member.getRank())
-                .profileImg(member.getProfileImage())
-                .updatedAt(String.valueOf(member.getUpdatedAt()))
-                .gameStyleResponseDTOList(dtoList)
-                .build();
+            .email(member.getEmail())
+            .gameName(member.getGameName())
+            .tag(member.getTag())
+            .tier(member.getTier())
+            .rank(member.getRank())
+            .profileImg(member.getProfileImage())
+            .updatedAt(String.valueOf(member.getUpdatedAt()))
+            .gameStyleResponseDTOList(dtoList)
+            .build();
+    }
+
+    public static MemberResponse.friendInfoDTO toFriendInfoDto(Friend friend) {
+        return MemberResponse.friendInfoDTO.builder()
+            .memberId(friend.getToMember().getId())
+            .name(friend.getToMember().getGameName())
+            .memberProfileImg(friend.getToMember().getProfileImage())
+            .isLiked(friend.getIsLiked())
+            .build();
     }
 
 }

--- a/src/main/java/com/gamegoo/domain/FriendRequests.java
+++ b/src/main/java/com/gamegoo/domain/FriendRequests.java
@@ -20,15 +20,15 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Friend extends BaseDateTimeEntity {
+public class FriendRequests extends BaseDateTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "friend_id")
+    @Column(name = "friend_request_id")
     private Long id;
 
     @Column(nullable = false)
-    private Boolean isLiked;
+    private Boolean isApproved;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "from_member_id", nullable = false)

--- a/src/main/java/com/gamegoo/dto/member/MemberResponse.java
+++ b/src/main/java/com/gamegoo/dto/member/MemberResponse.java
@@ -1,15 +1,20 @@
 package com.gamegoo.dto.member;
 
-import lombok.*;
-
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 public class MemberResponse {
+
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class blockListDTO {
+
         List<blockedMemberDTO> blocked_member_dto_list;
         Integer list_size;
         Integer total_page;
@@ -23,6 +28,7 @@ public class MemberResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class blockedMemberDTO {
+
         Long member_id;
         String profile_img;
         String email;
@@ -33,6 +39,7 @@ public class MemberResponse {
     @Setter
     @AllArgsConstructor
     public static class LoginResponseDTO {
+
         String accessToken;
         String refreshToken;
         String name;
@@ -44,6 +51,7 @@ public class MemberResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class GameStyleResponseDTO {
+
         Long gameStyleId;
         String gameStyleName;
     }
@@ -52,6 +60,7 @@ public class MemberResponse {
     @Setter
     @AllArgsConstructor
     public static class RefreshTokenResponseDTO {
+
         String accessToken;
         String refreshToken;
     }
@@ -61,6 +70,7 @@ public class MemberResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class myProfileMemberDTO {
+
         String profileImg;
         String email;
         String gameName;
@@ -69,5 +79,17 @@ public class MemberResponse {
         String rank;
         String updatedAt;
         List<GameStyleResponseDTO> gameStyleResponseDTOList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class friendInfoDTO {
+
+        Long memberId;
+        String name;
+        String memberProfileImg;
+        boolean isLiked;
     }
 }

--- a/src/main/java/com/gamegoo/repository/member/FriendRepository.java
+++ b/src/main/java/com/gamegoo/repository/member/FriendRepository.java
@@ -1,0 +1,10 @@
+package com.gamegoo.repository.member;
+
+import com.gamegoo.domain.Friend;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FriendRepository extends JpaRepository<Friend, Long> {
+
+    List<Friend> findAllByFromMemberId(Long memberId);
+}


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
친구 목록 조회 API 구현 및 엔티티 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 친구 목록 조회 API 추가
- Friend 엔티티에서 is_Friend 제거
- FriendRequests 엔티티 추가

## ⏳ 작업 내용
- [x] 친구 목록 조회 API  구현
- [x] Friend 엔티티 수정 및 FriendRequests 엔티티 추가
- [x] 배포 db 동기화 및 더미데이터 설정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
