### PR TITLE
[Feat/90] 채팅방 입장 API 구현

### DIFF
--- a/src/main/generated/com/gamegoo/domain/chat/QChat.java
+++ b/src/main/generated/com/gamegoo/domain/chat/QChat.java
@@ -35,6 +35,8 @@ public class QChat extends EntityPathBase<Chat> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
+    public final NumberPath<Long> timestamp = createNumber("timestamp", Long.class);
+
     public final com.gamegoo.domain.QMember toMember;
 
     //inherited

--- a/src/main/java/com/gamegoo/controller/chat/ChatController.java
+++ b/src/main/java/com/gamegoo/controller/chat/ChatController.java
@@ -57,4 +57,14 @@ public class ChatController {
         return ApiResponse.onSuccess(chatQueryService.getChatroomList(memberId));
     }
 
+    @Operation(summary = "채팅방 입장 API", description = "특정 채팅방에 입장하는 API 입니다. 채팅 상대의 id, 프로필 이미지, 닉네임 및 해당 채팅방의 안읽은 메시지 및 최근 메시지 목록을 리턴합니다.")
+    @GetMapping("/chat/{chatroomUuid}/enter")
+    public ApiResponse<ChatResponse.ChatroomEnterDTO> enterChatroom(
+        @PathVariable(name = "chatroomUuid") String chatroomUuid
+    ) {
+        Long memberId = JWTUtil.getCurrentUserId();
+
+        return ApiResponse.onSuccess(chatCommandService.enterChatroom(chatroomUuid, memberId));
+    }
+
 }

--- a/src/main/java/com/gamegoo/controller/chat/ChatController.java
+++ b/src/main/java/com/gamegoo/controller/chat/ChatController.java
@@ -15,6 +15,7 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,18 +41,18 @@ public class ChatController {
 
     @Operation(summary = "채팅방 생성 API", description = "채팅방을 생성하는 API 입니다.")
     @PostMapping("/chatroom/create/test")
-    public ApiResponse<ChatResponse.ChatroomCreateResultDto> createChatroom(
+    public ApiResponse<ChatResponse.ChatroomCreateResultDTO> createChatroom(
         @RequestBody @Valid ChatRequest.ChatroomCreateRequest request
     ) {
         Long memberId = JWTUtil.getCurrentUserId();
         Chatroom chatroom = chatCommandService.createChatroom(request, memberId);
         return ApiResponse.onSuccess(
-            ChatConverter.toChatroomCreateResultDto(chatroom, request.getTargetMemberId()));
+            ChatConverter.toChatroomCreateResultDTO(chatroom, request.getTargetMemberId()));
     }
 
     @Operation(summary = "채팅방 목록 조회 API", description = "회원이 속한 채팅방 목록을 조회하는 API 입니다.")
     @GetMapping("/member/chatroom")
-    public ApiResponse<List<ChatResponse.ChatroomViewDto>> getChatroom() {
+    public ApiResponse<List<ChatResponse.ChatroomViewDTO>> getChatroom() {
         Long memberId = JWTUtil.getCurrentUserId();
 
         return ApiResponse.onSuccess(chatQueryService.getChatroomList(memberId));

--- a/src/main/java/com/gamegoo/converter/ChatConverter.java
+++ b/src/main/java/com/gamegoo/converter/ChatConverter.java
@@ -5,10 +5,10 @@ import com.gamegoo.dto.chat.ChatResponse;
 
 public class ChatConverter {
 
-    public static ChatResponse.ChatroomCreateResultDto toChatroomCreateResultDto(Chatroom chatroom,
+    public static ChatResponse.ChatroomCreateResultDTO toChatroomCreateResultDTO(Chatroom chatroom,
         Long targetMemberId) {
 
-        return ChatResponse.ChatroomCreateResultDto.builder()
+        return ChatResponse.ChatroomCreateResultDTO.builder()
             .chatroomId(chatroom.getId())
             .uuid(chatroom.getUuid())
             .postUrl(chatroom.getPostUrl())

--- a/src/main/java/com/gamegoo/domain/chat/Chat.java
+++ b/src/main/java/com/gamegoo/domain/chat/Chat.java
@@ -2,9 +2,19 @@ package com.gamegoo.domain.chat;
 
 import com.gamegoo.domain.Member;
 import com.gamegoo.domain.common.BaseDateTimeEntity;
-import lombok.*;
-
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -12,6 +22,7 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Chat extends BaseDateTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "chat_id")
@@ -19,6 +30,9 @@ public class Chat extends BaseDateTimeEntity {
 
     @Column(nullable = false, length = 1000)
     private String contents;
+
+    @Column(nullable = false)
+    private Long timestamp;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chatroom_id", nullable = false)
@@ -29,6 +43,6 @@ public class Chat extends BaseDateTimeEntity {
     private Member fromMember;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "to_member_id", nullable = false)
+    @JoinColumn(name = "to_member_id")
     private Member toMember;
 }

--- a/src/main/java/com/gamegoo/domain/chat/MemberChatroom.java
+++ b/src/main/java/com/gamegoo/domain/chat/MemberChatroom.java
@@ -48,4 +48,9 @@ public class MemberChatroom extends BaseDateTimeEntity {
         this.member = member;
         this.member.getMemberChatroomList().add(this);
     }
+
+    public void updateLastViewDate(LocalDateTime lastViewDate) {
+        this.lastViewDate = lastViewDate;
+    }
+
 }

--- a/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
+++ b/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
@@ -1,5 +1,6 @@
 package com.gamegoo.dto.chat;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +12,7 @@ public class ChatResponse {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ChatroomCreateResultDto {
+    public static class ChatroomCreateResultDTO {
 
         Long chatroomId;
         String uuid;
@@ -23,7 +24,7 @@ public class ChatResponse {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ChatroomViewDto {
+    public static class ChatroomViewDTO {
 
         Long chatroomId;
         String uuid;

--- a/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
+++ b/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
@@ -33,4 +33,43 @@ public class ChatResponse {
         String lastMsgAt;
         Integer notReadMsgCnt;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChatroomEnterDTO {
+
+        Long memberId;
+        String gameName;
+        String memberProfileImg;
+        ChatMessageListDTO chatMessageList;
+
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChatMessageListDTO {
+
+        List<ChatMessageDTO> chatMessageDtoList;
+        Integer list_size;
+        Boolean has_next;
+        Long next_cursor;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChatMessageDTO {
+
+        Long senderId;
+        String senderName;
+        String senderProfileImg;
+        String message;
+        String createdAt;
+        Long timestamp;
+    }
 }

--- a/src/main/java/com/gamegoo/repository/chat/ChatRepositoryCustom.java
+++ b/src/main/java/com/gamegoo/repository/chat/ChatRepositoryCustom.java
@@ -1,7 +1,13 @@
 package com.gamegoo.repository.chat;
 
+import com.gamegoo.domain.chat.Chat;
+import org.springframework.data.domain.Slice;
+
 public interface ChatRepositoryCustom {
 
     Integer countUnreadChats(Long chatroomId, Long memberChatroomId);
+
+    Slice<Chat> findRecentChats(Long chatroomId, Long memberChatroomId);
+
 
 }

--- a/src/main/java/com/gamegoo/repository/chat/ChatRepositoryCustomImpl.java
+++ b/src/main/java/com/gamegoo/repository/chat/ChatRepositoryCustomImpl.java
@@ -3,11 +3,18 @@ package com.gamegoo.repository.chat;
 import static com.gamegoo.domain.chat.QChat.chat;
 import static com.gamegoo.domain.chat.QMemberChatroom.memberChatroom;
 
+import com.gamegoo.domain.chat.Chat;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Collections;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -31,6 +38,60 @@ public class ChatRepositoryCustomImpl implements ChatRepositoryCustom {
         return countResult != null ? countResult.intValue() : null;
     }
 
+    @Override
+    public Slice<Chat> findRecentChats(Long chatroomId, Long memberChatroomId) {
+        Pageable pageable = PageRequest.of(0, PAGE_SIZE);
+
+        // 안읽은 메시지 모두 조회
+        List<Chat> unreadChats = queryFactory.selectFrom(chat)
+            .where(
+                chat.chatroom.id.eq(chatroomId),
+                createdAtGreaterThanSubQuery(memberChatroomId)
+            )
+            .orderBy(chat.createdAt.desc())
+            .fetch();
+
+        if (unreadChats.size() >= 20) { // 안읽은 메시지 개수가 20개 이상인 경우, 안읽은 메시지만 모두 리턴
+
+            // 가장 오래된 unreadChat의 timestamp를 기준으로 추가 메시지 조회 (hasNext 여부 판단을 위함)
+            Chat oldestUnreadChat = unreadChats.get(unreadChats.size() - 1);
+            List<Chat> additionalChats = queryFactory.selectFrom(chat)
+                .where(
+                    chat.chatroom.id.eq(oldestUnreadChat.getChatroom().getId()),
+                    createdBefore(oldestUnreadChat.getTimestamp())
+                )
+                .orderBy(chat.createdAt.desc())
+                .limit(1) // 하나의 추가 메시지만 확인하면 충분
+                .fetch();
+
+            boolean hasNext = !additionalChats.isEmpty();
+
+            // createdAt 오름차순으로 정렬
+            Collections.reverse(unreadChats);
+
+            return new SliceImpl<>(unreadChats, Pageable.unpaged(), hasNext);
+        } else { // 안읽은 메시지가 20개 미만인 경우, 최근 메시지 20개를 조회해 리턴
+            List<Chat> chats = queryFactory.selectFrom(chat)
+                .where(
+                    chat.chatroom.id.eq(chatroomId)
+                )
+                .orderBy(chat.createdAt.desc())
+                .limit(pageable.getPageSize() + 1) // 다음 페이지가 있는지 확인하기 위해 +1
+                .fetch();
+
+            boolean hasNext = false;
+            if (chats.size() > pageable.getPageSize()) {
+                chats.remove(pageable.getPageSize());
+                hasNext = true;
+            }
+
+            // createdAt 오름차순으로 정렬
+            Collections.reverse(chats);
+
+            return new SliceImpl<>(chats, pageable, hasNext);
+        }
+    }
+
     //--- BooleanExpression ---//
     private BooleanExpression createdAtGreaterThanSubQuery(Long memberChatroomId) {
         return chat.createdAt.gt(
@@ -38,5 +99,9 @@ public class ChatRepositoryCustomImpl implements ChatRepositoryCustom {
                 .from(memberChatroom)
                 .where(memberChatroom.id.eq(memberChatroomId))
         );
+    }
+
+    private BooleanExpression createdBefore(Long cursorTimestamp) {
+        return cursorTimestamp != null ? chat.timestamp.lt(cursorTimestamp) : null;
     }
 }

--- a/src/main/java/com/gamegoo/repository/chat/ChatroomRepository.java
+++ b/src/main/java/com/gamegoo/repository/chat/ChatroomRepository.java
@@ -2,6 +2,7 @@ package com.gamegoo.repository.chat;
 
 import com.gamegoo.domain.chat.Chatroom;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,5 +11,7 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
 
     @Query("SELECT c.uuid FROM MemberChatroom mc JOIN mc.chatroom c WHERE mc.member.id = :memberId AND mc.lastJoinDate IS NOT NULL")
     List<String> findActiveChatroomUuidsByMemberId(@Param("memberId") Long memberId);
+
+    Optional<Chatroom> findByUuid(String uuid);
 
 }

--- a/src/main/java/com/gamegoo/repository/chat/MemberChatroomRepository.java
+++ b/src/main/java/com/gamegoo/repository/chat/MemberChatroomRepository.java
@@ -2,6 +2,7 @@ package com.gamegoo.repository.chat;
 
 import com.gamegoo.domain.Member;
 import com.gamegoo.domain.chat.MemberChatroom;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,5 +13,8 @@ public interface MemberChatroomRepository extends JpaRepository<MemberChatroom, 
     @Query("SELECT mc.member FROM MemberChatroom mc WHERE mc.chatroom.id = :chatroomId AND mc.member.id != :memberId")
     Member findTargetMemberByChatroomIdAndMemberId(@Param("chatroomId") Long chatroomId,
         @Param("memberId") Long memberId);
+
+    Optional<MemberChatroom> findByMemberIdAndChatroomId(Long memberId, Long chatroomId);
+
 
 }

--- a/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
@@ -3,15 +3,24 @@ package com.gamegoo.service.chat;
 import com.gamegoo.apiPayload.code.status.ErrorStatus;
 import com.gamegoo.apiPayload.exception.handler.ChatHandler;
 import com.gamegoo.domain.Member;
+import com.gamegoo.domain.chat.Chat;
 import com.gamegoo.domain.chat.Chatroom;
 import com.gamegoo.domain.chat.MemberChatroom;
 import com.gamegoo.dto.chat.ChatRequest;
+import com.gamegoo.dto.chat.ChatResponse;
+import com.gamegoo.dto.chat.ChatResponse.ChatroomEnterDTO;
+import com.gamegoo.repository.chat.ChatRepository;
 import com.gamegoo.repository.chat.ChatroomRepository;
 import com.gamegoo.repository.chat.MemberChatroomRepository;
 import com.gamegoo.repository.member.MemberRepository;
 import com.gamegoo.service.member.ProfileService;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +32,7 @@ public class ChatCommandService {
     private final MemberRepository memberRepository;
     private final MemberChatroomRepository memberChatroomRepository;
     private final ChatroomRepository chatroomRepository;
+    private final ChatRepository chatRepository;
 
     /**
      * 대상 회원과의 채팅방 생성
@@ -67,6 +77,70 @@ public class ChatCommandService {
         memberChatroomRepository.save(targetMemberChatroom);
 
         return savedChatroom;
+    }
+
+    /**
+     * chatroomUuid에 해당하는 채팅방에 입장 처리: 채팅 상대 회원 정보 조회, 메시지 내역 조회 및 lastViewDate 업데이트
+     *
+     * @param chatroomUuid
+     * @param memberId
+     * @return
+     */
+    @Transactional
+    public ChatResponse.ChatroomEnterDTO enterChatroom(String chatroomUuid, Long memberId) {
+        // chatroom 엔티티 조회 및 해당 회원의 채팅방이 맞는지 검증
+        Chatroom chatroom = chatroomRepository.findByUuid(chatroomUuid)
+            .orElseThrow(() -> new ChatHandler(ErrorStatus.CHATROOM_NOT_EXIST));
+
+        MemberChatroom memberChatroom = memberChatroomRepository.findByMemberIdAndChatroomId(
+                memberId, chatroom.getId())
+            .orElseThrow(() -> new ChatHandler(ErrorStatus.CHATROOM_ACCESS_DENIED));
+
+        // 해당 회원이 퇴장한 채팅방은 아닌지도 나중에 검증 추가하기
+
+        // 채팅 상대 회원 정보 조회
+        Member targetMember = memberChatroomRepository.findTargetMemberByChatroomIdAndMemberId(
+            chatroom.getId(), memberId);
+
+        // 최근 메시지 내역 조회
+        Slice<Chat> recentChats = chatRepository.findRecentChats(chatroom.getId(),
+            memberChatroom.getId());
+
+        // 해당 채팅방의 lastViewDate 업데이트
+        memberChatroom.updateLastViewDate(LocalDateTime.now());
+
+        // chatMessageDtoList 생성
+        List<ChatResponse.ChatMessageDTO> chatMessageDtoList = recentChats.stream()
+            .map(chat -> {
+                // ISO 8601 형식의 문자열로 변환
+                String createdAtIoString = chat.getCreatedAt()
+                    .format(DateTimeFormatter.ISO_DATE_TIME);
+
+                return ChatResponse.ChatMessageDTO.builder()
+                    .senderId(chat.getFromMember().getId())
+                    .senderName(chat.getFromMember().getGameName())
+                    .senderProfileImg(chat.getFromMember().getProfileImage())
+                    .message(chat.getContents())
+                    .createdAt(createdAtIoString)
+                    .timestamp(chat.getTimestamp())
+                    .build();
+            }).collect(Collectors.toList());
+
+        // ChatMessageListDTO 생성
+        ChatResponse.ChatMessageListDTO chatMessageListDTO = ChatResponse.ChatMessageListDTO.builder()
+            .chatMessageDtoList(chatMessageDtoList)
+            .list_size(chatMessageDtoList.size())
+            .has_next(recentChats.hasNext())
+            .next_cursor(recentChats.hasNext() ? recentChats.getContent().get(0).getTimestamp()
+                : null) // next cursor를 현재 chat list의 가장 오래된 chat의 timestamp로 주기
+            .build();
+
+        return ChatroomEnterDTO.builder()
+            .memberId(targetMember.getId())
+            .gameName(targetMember.getGameName())
+            .memberProfileImg(targetMember.getProfileImage())
+            .chatMessageList(chatMessageListDTO)
+            .build();
     }
 
 }

--- a/src/main/java/com/gamegoo/service/chat/ChatQueryService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatQueryService.java
@@ -45,14 +45,14 @@ public class ChatQueryService {
      * @return
      */
     @Transactional(readOnly = true)
-    public List<ChatResponse.ChatroomViewDto> getChatroomList(Long memberId) {
+    public List<ChatResponse.ChatroomViewDTO> getChatroomList(Long memberId) {
         Member member = profileService.findMember(memberId);
 
         // 현재 참여중인 memberChatroom을 각 memberChatroom에 속한 chat의 마지막 createdAt 기준 desc 정렬해 조회
         List<MemberChatroom> activeMemberChatroom = memberChatroomRepository.findActiveMemberChatroomOrderByLastChat(
             member.getId());
 
-        List<ChatResponse.ChatroomViewDto> chatroomViewDtoList = activeMemberChatroom.stream()
+        List<ChatResponse.ChatroomViewDTO> chatroomViewDtoList = activeMemberChatroom.stream()
             .map(memberChatroom -> {
                 // 채팅 상대 회원 조회
                 Member targetMember = memberChatroomRepository.findTargetMemberByChatroomIdAndMemberId(
@@ -74,7 +74,7 @@ public class ChatQueryService {
                         .format(DateTimeFormatter.ISO_DATE_TIME);
                 }
 
-                return ChatResponse.ChatroomViewDto.builder()
+                return ChatResponse.ChatroomViewDTO.builder()
                     .chatroomId(chatroom.getId())
                     .uuid(chatroom.getUuid())
                     .targetMemberImg(targetMember.getProfileImage())


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 채팅방 입장 API 구현
- 최근 메시지 조회용 custom query 추가
- responseDto -> responseDTO로 이름 변경
- Chat 엔티티에 timestamp 추가

## ⏳ 작업 내용
- [x] 채팅방 입장 API 구현
- [x] 최근 메시지 조회용 custom query 추가
- [x] responseDto -> responseDTO로 이름 변경

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
