### PR TITLE
[Feat/99] 채팅방 시작, 나가기 기능 구현 및 리팩토링

### DIFF
--- a/src/main/generated/com/gamegoo/domain/chat/QChatroom.java
+++ b/src/main/generated/com/gamegoo/domain/chat/QChatroom.java
@@ -29,8 +29,6 @@ public class QChatroom extends EntityPathBase<Chatroom> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
-    public final StringPath postUrl = createString("postUrl");
-
     public final com.gamegoo.domain.QMember startMember;
 
     //inherited

--- a/src/main/java/com/gamegoo/config/SecurityConfig.java
+++ b/src/main/java/com/gamegoo/config/SecurityConfig.java
@@ -46,7 +46,8 @@ public class SecurityConfig {
     public JWTFilter jwtFilter() {
         List<String> excludedPaths = Arrays.asList("/swagger-ui/", "/v3/api-docs",
             "/v1/member/join", "/v1/member/login", "/v1/member/email", "/v1/member/refresh",
-            "/v1/member/riot","/v1/posts/list","/v1/posts/list/{boardId}");
+            "/v1/member/riot", "/v1/posts/list", "/v1/posts/list/{boardId}",
+            "/v1/chatroom/create/matched");
         return new JWTFilter(jwtUtil, excludedPaths, customUserDetailService);
 
     }
@@ -66,7 +67,8 @@ public class SecurityConfig {
             .cors(withDefaults())
             .authorizeHttpRequests((auth) -> auth
                 .antMatchers("/", "/v1/member/join", "/v1/member/login", "/v1/member/email/**",
-                    "/v1/member/refresh", "/v1/member/riot","/v1/posts/list/**").permitAll()
+                    "/v1/member/refresh", "/v1/member/riot", "/v1/posts/list/**",
+                    "/v1/chatroom/create/matched").permitAll()
                 .antMatchers("/", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                 .anyRequest().authenticated())
             .addFilterBefore(new JWTExceptionHandlerFilter(),

--- a/src/main/java/com/gamegoo/config/SecurityConfig.java
+++ b/src/main/java/com/gamegoo/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
         List<String> excludedPaths = Arrays.asList("/swagger-ui/", "/v3/api-docs",
             "/v1/member/join", "/v1/member/login", "/v1/member/email", "/v1/member/refresh",
             "/v1/member/riot", "/v1/posts/list", "/v1/posts/list/{boardId}",
-            "/v1/chatroom/create/matched");
+            "/v1/test/chatroom/create/matched");
         return new JWTFilter(jwtUtil, excludedPaths, customUserDetailService);
 
     }
@@ -68,7 +68,7 @@ public class SecurityConfig {
             .authorizeHttpRequests((auth) -> auth
                 .antMatchers("/", "/v1/member/join", "/v1/member/login", "/v1/member/email/**",
                     "/v1/member/refresh", "/v1/member/riot", "/v1/posts/list/**",
-                    "/v1/chatroom/create/matched").permitAll()
+                    "/v1/test/chatroom/create/matched").permitAll()
                 .antMatchers("/", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                 .anyRequest().authenticated())
             .addFilterBefore(new JWTExceptionHandlerFilter(),

--- a/src/main/java/com/gamegoo/controller/chat/ChatController.java
+++ b/src/main/java/com/gamegoo/controller/chat/ChatController.java
@@ -62,7 +62,7 @@ public class ChatController {
         Chatroom chatroomByMatch = chatCommandService.createChatroomByMatch(request);
         return ApiResponse.onSuccess(
             ChatConverter.toChatroomCreateResultDTO(chatroomByMatch, null));
-        
+
     }
 
     @Operation(summary = "채팅방 목록 조회 API", description = "회원이 속한 채팅방 목록을 조회하는 API 입니다.")
@@ -100,7 +100,7 @@ public class ChatController {
         "cursor 파라미터를 보내지 않으면, 해당 채팅방의 가장 최근 메시지 내역을 조회합니다.")
     @GetMapping("/chat/{chatroomUuid}/messages")
     @Parameter(name = "cursor", description = "페이징을 위한 커서, 13자리 timestamp integer를 보내주세요. (UTC 기준)")
-    public ApiResponse<Object> getChatMessages(
+    public ApiResponse<ChatResponse.ChatMessageListDTO> getChatMessages(
         @PathVariable(name = "chatroomUuid") String chatroomUuid,
         @RequestParam(name = "cursor", required = false) Long cursor
     ) {
@@ -123,4 +123,16 @@ public class ChatController {
         chatCommandService.readChatMessages(chatroomUuid, timestamp, memberId);
         return ApiResponse.onSuccess("채팅 메시지 읽음 처리 성공");
     }
+
+    @Operation(summary = "채팅방 나가기 API", description = "채팅방 나가기 API 입니다.")
+    @GetMapping("/chatroom/{chatroomUuid}/exit")
+    public ApiResponse<Object> exitChatroom(
+        @PathVariable(name = "chatroomUuid") String chatroomUuid
+    ) {
+        Long memberId = JWTUtil.getCurrentUserId();
+
+        chatCommandService.exitChatroom(chatroomUuid, memberId);
+        return ApiResponse.onSuccess("채팅방 나가기 성공");
+    }
+
 }

--- a/src/main/java/com/gamegoo/controller/chat/ChatController.java
+++ b/src/main/java/com/gamegoo/controller/chat/ChatController.java
@@ -124,7 +124,7 @@ public class ChatController {
         return ApiResponse.onSuccess("채팅방 나가기 성공");
     }
 
-    @Operation(summary = "채팅방 생성 API", description = "채팅방을 생성하는 API 입니다. 서버 테스트용!!")
+    @Operation(summary = "채팅방 생성 API (서버 테스트용)", description = "채팅방을 생성하는 API 입니다. 서버 테스트용!!")
     @PostMapping("/test/chatroom/create")
     public ApiResponse<ChatResponse.ChatroomCreateResultDTO> createChatroom(
         @RequestBody @Valid ChatRequest.ChatroomCreateRequest request
@@ -135,7 +135,7 @@ public class ChatController {
             ChatConverter.toChatroomCreateResultDTO(chatroom, request.getTargetMemberId()));
     }
 
-    @Operation(summary = "채팅방 생성 by Matching API", description = "매칭을 통한 채팅방을 생성하는 API 입니다. 서버 테스트용!!")
+    @Operation(summary = "채팅방 생성 by Matching API (서버 테스트용)", description = "매칭을 통한 채팅방을 생성하는 API 입니다. 서버 테스트용!!")
     @PostMapping("/test/chatroom/create/matched")
     public ApiResponse<ChatResponse.ChatroomCreateResultDTO> createChatroomByMatching(
         @RequestBody @Valid ChatRequest.ChatroomCreateByMatchRequest request

--- a/src/main/java/com/gamegoo/controller/chat/ChatController.java
+++ b/src/main/java/com/gamegoo/controller/chat/ChatController.java
@@ -43,6 +43,14 @@ public class ChatController {
         return ApiResponse.onSuccess(chatroomUuids);
     }
 
+    @Operation(summary = "채팅방 목록 조회 API", description = "회원이 속한 채팅방 목록을 조회하는 API 입니다.")
+    @GetMapping("/member/chatroom")
+    public ApiResponse<List<ChatResponse.ChatroomViewDTO>> getChatroom() {
+        Long memberId = JWTUtil.getCurrentUserId();
+
+        return ApiResponse.onSuccess(chatQueryService.getChatroomList(memberId));
+    }
+
     @Operation(summary = "채팅방 생성 API", description = "채팅방을 생성하는 API 입니다.")
     @PostMapping("/chatroom/create/test")
     public ApiResponse<ChatResponse.ChatroomCreateResultDTO> createChatroom(
@@ -63,14 +71,6 @@ public class ChatController {
         return ApiResponse.onSuccess(
             ChatConverter.toChatroomCreateResultDTO(chatroomByMatch, null));
 
-    }
-
-    @Operation(summary = "채팅방 목록 조회 API", description = "회원이 속한 채팅방 목록을 조회하는 API 입니다.")
-    @GetMapping("/member/chatroom")
-    public ApiResponse<List<ChatResponse.ChatroomViewDTO>> getChatroom() {
-        Long memberId = JWTUtil.getCurrentUserId();
-
-        return ApiResponse.onSuccess(chatQueryService.getChatroomList(memberId));
     }
 
     @Operation(summary = "채팅방 입장 API", description = "특정 채팅방에 입장하는 API 입니다. 채팅 상대의 id, 프로필 이미지, 닉네임 및 해당 채팅방의 안읽은 메시지 및 최근 메시지 목록을 리턴합니다.")
@@ -112,7 +112,7 @@ public class ChatController {
     }
 
     @Operation(summary = "채팅 메시지 읽음 처리 API", description = "특정 채팅방의 메시지를 읽음 처리하는 API 입니다.")
-    @GetMapping("/chatroom/{chatroomUuid}/read")
+    @GetMapping("/chat/{chatroomUuid}/read")
     @Parameter(name = "timestamp", description = "특정 메시지를 읽음 처리하는 경우, 그 메시지의 timestamp를 함께 보내주세요.")
     public ApiResponse<String> readChatMessage(
         @PathVariable(name = "chatroomUuid") String chatroomUuid,
@@ -125,7 +125,7 @@ public class ChatController {
     }
 
     @Operation(summary = "채팅방 나가기 API", description = "채팅방 나가기 API 입니다.")
-    @GetMapping("/chatroom/{chatroomUuid}/exit")
+    @GetMapping("/chat/{chatroomUuid}/exit")
     public ApiResponse<Object> exitChatroom(
         @PathVariable(name = "chatroomUuid") String chatroomUuid
     ) {

--- a/src/main/java/com/gamegoo/controller/chat/ChatController.java
+++ b/src/main/java/com/gamegoo/controller/chat/ChatController.java
@@ -51,26 +51,15 @@ public class ChatController {
         return ApiResponse.onSuccess(chatQueryService.getChatroomList(memberId));
     }
 
-    @Operation(summary = "채팅방 생성 API", description = "채팅방을 생성하는 API 입니다.")
-    @PostMapping("/chatroom/create/test")
-    public ApiResponse<ChatResponse.ChatroomCreateResultDTO> createChatroom(
-        @RequestBody @Valid ChatRequest.ChatroomCreateRequest request
+    @Operation(summary = "채팅방 시작 API", description = "특정 대상 회원과의 채팅방을 시작하는 API 입니다.\n\n" +
+        "대상 회원과의 채팅방이 이미 존재하는 경우, 채팅방 uuid, 상대 회원 정보와 채팅 메시지 내역을 리턴합니다.\n\n" +
+        "대상 회원과의 채팅방이 존재하지 않는 경우, 채팅방을 새로 생성해 해당 채팅방의 uuid, 상대 회원 정보를 리턴합니다.")
+    @PostMapping("/chat/start")
+    public ApiResponse<ChatResponse.ChatroomEnterDTO> startChatroom(
+        @RequestBody @Valid ChatRequest.ChatroomStartRequest request
     ) {
         Long memberId = JWTUtil.getCurrentUserId();
-        Chatroom chatroom = chatCommandService.createChatroom(request, memberId);
-        return ApiResponse.onSuccess(
-            ChatConverter.toChatroomCreateResultDTO(chatroom, request.getTargetMemberId()));
-    }
-
-    @Operation(summary = "채팅방 생성 by Matching API", description = "매칭을 통한 채팅방을 생성하는 API 입니다.")
-    @PostMapping("/chatroom/create/matched")
-    public ApiResponse<ChatResponse.ChatroomCreateResultDTO> createChatroomByMatching(
-        @RequestBody @Valid ChatRequest.ChatroomCreateByMatchRequest request
-    ) {
-        Chatroom chatroomByMatch = chatCommandService.createChatroomByMatch(request);
-        return ApiResponse.onSuccess(
-            ChatConverter.toChatroomCreateResultDTO(chatroomByMatch, null));
-
+        return ApiResponse.onSuccess(chatCommandService.startChatroom(request, memberId));
     }
 
     @Operation(summary = "채팅방 입장 API", description = "특정 채팅방에 입장하는 API 입니다. 채팅 상대의 id, 프로필 이미지, 닉네임 및 해당 채팅방의 안읽은 메시지 및 최근 메시지 목록을 리턴합니다.")
@@ -135,4 +124,25 @@ public class ChatController {
         return ApiResponse.onSuccess("채팅방 나가기 성공");
     }
 
+    @Operation(summary = "채팅방 생성 API", description = "채팅방을 생성하는 API 입니다. 서버 테스트용!!")
+    @PostMapping("/test/chatroom/create")
+    public ApiResponse<ChatResponse.ChatroomCreateResultDTO> createChatroom(
+        @RequestBody @Valid ChatRequest.ChatroomCreateRequest request
+    ) {
+        Long memberId = JWTUtil.getCurrentUserId();
+        Chatroom chatroom = chatCommandService.createChatroom(request, memberId);
+        return ApiResponse.onSuccess(
+            ChatConverter.toChatroomCreateResultDTO(chatroom, request.getTargetMemberId()));
+    }
+
+    @Operation(summary = "채팅방 생성 by Matching API", description = "매칭을 통한 채팅방을 생성하는 API 입니다. 서버 테스트용!!")
+    @PostMapping("/test/chatroom/create/matched")
+    public ApiResponse<ChatResponse.ChatroomCreateResultDTO> createChatroomByMatching(
+        @RequestBody @Valid ChatRequest.ChatroomCreateByMatchRequest request
+    ) {
+        Chatroom chatroomByMatch = chatCommandService.createChatroomByMatch(request);
+        return ApiResponse.onSuccess(
+            ChatConverter.toChatroomCreateResultDTO(chatroomByMatch, null));
+
+    }
 }

--- a/src/main/java/com/gamegoo/controller/chat/ChatController.java
+++ b/src/main/java/com/gamegoo/controller/chat/ChatController.java
@@ -54,6 +54,17 @@ public class ChatController {
             ChatConverter.toChatroomCreateResultDTO(chatroom, request.getTargetMemberId()));
     }
 
+    @Operation(summary = "채팅방 생성 by Matching API", description = "매칭을 통한 채팅방을 생성하는 API 입니다.")
+    @PostMapping("/chatroom/create/matched")
+    public ApiResponse<ChatResponse.ChatroomCreateResultDTO> createChatroomByMatching(
+        @RequestBody @Valid ChatRequest.ChatroomCreateByMatchRequest request
+    ) {
+        Chatroom chatroomByMatch = chatCommandService.createChatroomByMatch(request);
+        return ApiResponse.onSuccess(
+            ChatConverter.toChatroomCreateResultDTO(chatroomByMatch, null));
+        
+    }
+
     @Operation(summary = "채팅방 목록 조회 API", description = "회원이 속한 채팅방 목록을 조회하는 API 입니다.")
     @GetMapping("/member/chatroom")
     public ApiResponse<List<ChatResponse.ChatroomViewDTO>> getChatroom() {

--- a/src/main/java/com/gamegoo/converter/ChatConverter.java
+++ b/src/main/java/com/gamegoo/converter/ChatConverter.java
@@ -16,7 +16,6 @@ public class ChatConverter {
         return ChatResponse.ChatroomCreateResultDTO.builder()
             .chatroomId(chatroom.getId())
             .uuid(chatroom.getUuid())
-            .postUrl(chatroom.getPostUrl())
             .targetMemberId(targetMemberId)
             .build();
     }

--- a/src/main/java/com/gamegoo/domain/chat/Chatroom.java
+++ b/src/main/java/com/gamegoo/domain/chat/Chatroom.java
@@ -30,9 +30,6 @@ public class Chatroom extends BaseDateTimeEntity {
 
     private String uuid;
 
-    @Column(columnDefinition = "TEXT")
-    private String postUrl;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "start_member_id")
     private Member startMember;

--- a/src/main/java/com/gamegoo/domain/chat/MemberChatroom.java
+++ b/src/main/java/com/gamegoo/domain/chat/MemberChatroom.java
@@ -53,4 +53,7 @@ public class MemberChatroom extends BaseDateTimeEntity {
         this.lastViewDate = lastViewDate;
     }
 
+    public void updateLastJoinDate(LocalDateTime lastJoinDate) {
+        this.lastJoinDate = lastJoinDate;
+    }
 }

--- a/src/main/java/com/gamegoo/dto/chat/ChatRequest.java
+++ b/src/main/java/com/gamegoo/dto/chat/ChatRequest.java
@@ -1,5 +1,6 @@
 package com.gamegoo.dto.chat;
 
+import java.util.List;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
@@ -13,6 +14,13 @@ public class ChatRequest {
         Long targetMemberId;
 
         String postUrl;
+    }
+
+    @Getter
+    public static class ChatroomCreateByMatchRequest {
+
+        @NotNull
+        List<Long> memberList;
     }
 
     @Getter

--- a/src/main/java/com/gamegoo/dto/chat/ChatRequest.java
+++ b/src/main/java/com/gamegoo/dto/chat/ChatRequest.java
@@ -17,6 +17,15 @@ public class ChatRequest {
     }
 
     @Getter
+    public static class ChatroomStartRequest {
+
+        @NotNull
+        Long targetMemberId;
+
+        String postUrl;
+    }
+
+    @Getter
     public static class ChatroomCreateByMatchRequest {
 
         @NotNull

--- a/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
+++ b/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
@@ -41,6 +41,7 @@ public class ChatResponse {
     @AllArgsConstructor
     public static class ChatroomEnterDTO {
 
+        String uuid;
         Long memberId;
         String gameName;
         String memberProfileImg;

--- a/src/main/java/com/gamegoo/repository/chat/ChatRepositoryCustom.java
+++ b/src/main/java/com/gamegoo/repository/chat/ChatRepositoryCustom.java
@@ -10,7 +10,8 @@ public interface ChatRepositoryCustom {
 
     Slice<Chat> findRecentChats(Long chatroomId, Long memberChatroomId);
 
-    Slice<Chat> findChatsByCursor(Long cursor, Long chatroomId, Pageable pageable);
+    Slice<Chat> findChatsByCursor(Long cursor, Long chatroomId, Long memberChatroomId,
+        Pageable pageable);
 
 
 }

--- a/src/main/java/com/gamegoo/repository/chat/ChatroomRepository.java
+++ b/src/main/java/com/gamegoo/repository/chat/ChatroomRepository.java
@@ -7,7 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
+public interface ChatroomRepository extends JpaRepository<Chatroom, Long>,
+    ChatroomRepositoryCustom {
 
     @Query("SELECT c.uuid FROM MemberChatroom mc JOIN mc.chatroom c WHERE mc.member.id = :memberId AND mc.lastJoinDate IS NOT NULL")
     List<String> findActiveChatroomUuidsByMemberId(@Param("memberId") Long memberId);

--- a/src/main/java/com/gamegoo/repository/chat/ChatroomRepositoryCustom.java
+++ b/src/main/java/com/gamegoo/repository/chat/ChatroomRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.gamegoo.repository.chat;
+
+import com.gamegoo.domain.chat.Chatroom;
+import java.util.Optional;
+
+public interface ChatroomRepositoryCustom {
+
+    Optional<Chatroom> findChatroomByMemberIds(Long memberId1, Long memberId2);
+
+}

--- a/src/main/java/com/gamegoo/repository/chat/ChatroomRepositoryCustomImpl.java
+++ b/src/main/java/com/gamegoo/repository/chat/ChatroomRepositoryCustomImpl.java
@@ -1,0 +1,38 @@
+package com.gamegoo.repository.chat;
+
+import static com.gamegoo.domain.chat.QChatroom.chatroom;
+import static com.gamegoo.domain.chat.QMemberChatroom.memberChatroom;
+
+import com.gamegoo.domain.chat.Chatroom;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ChatroomRepositoryCustomImpl implements ChatroomRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * memberId1, memberId2에 해당하는 chatroom 엔티티를 반환
+     *
+     * @param memberId1
+     * @param memberId2
+     * @return
+     */
+    @Override
+    public Optional<Chatroom> findChatroomByMemberIds(Long memberId1, Long memberId2) {
+        Chatroom chatroomEntity = queryFactory
+            .select(chatroom)
+            .from(memberChatroom)
+            .join(chatroom).on(memberChatroom.chatroom.id.eq(chatroom.id))
+            .where(memberChatroom.member.id.in(memberId1, memberId2))
+            .groupBy(memberChatroom.chatroom.id)
+            .having(memberChatroom.member.id.count().eq(2L))
+            .fetchFirst();
+
+        return Optional.ofNullable(chatroomEntity);
+    }
+}

--- a/src/main/java/com/gamegoo/repository/chat/MemberChatroomRepositoryCustomImpl.java
+++ b/src/main/java/com/gamegoo/repository/chat/MemberChatroomRepositoryCustomImpl.java
@@ -35,8 +35,10 @@ public class MemberChatroomRepositoryCustomImpl implements MemberChatroomReposit
                     new Coalesce<LocalDateTime>()
                         .add(JPAExpressions.select(chat.createdAt.max())
                             .from(chat)
-                            .where(chat.chatroom.eq(chatroom)))
-                        .add(chatroom.createdAt)
+                            .where(
+                                chat.chatroom.eq(chatroom),
+                                chat.createdAt.goe(memberChatroom.lastJoinDate)))
+                        .add(memberChatroom.lastJoinDate) // 해당 채팅방에 대화 내역이 없는 경우, lastJoinDate를 기준으로 정렬
                 )
             )
             .fetch();

--- a/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
@@ -219,7 +219,8 @@ public class ChatCommandService {
 
         // MemberChatroom의 lastViewDate 업데이트
         Chat savedChat = chatRepository.save(chat);
-        memberChatroom.updateLastViewDate(savedChat.getCreatedAt());
+        updateLastViewDateByAddChat(memberChatroom, savedChat.getCreatedAt());
+        //memberChatroom.updateLastViewDate(savedChat.getCreatedAt());
 
         return savedChat;
     }
@@ -250,6 +251,35 @@ public class ChatCommandService {
             Chat chat = chatRepository.findByChatroomAndTimestamp(chatroom, timestamp)
                 .orElseThrow(() -> new ChatHandler(ErrorStatus.CHAT_MESSAGE_NOT_FOUND));
             memberChatroom.updateLastViewDate(chat.getCreatedAt());
+        }
+    }
+
+    private void updateLastViewDateByAddChat(MemberChatroom memberChatroom,
+        LocalDateTime lastViewDate) {
+        // lastJoinDate가 null인 경우
+        if (memberChatroom.getLastJoinDate() == null) {
+            // lastViewDate 업데이트
+            memberChatroom.updateLastViewDate(lastViewDate);
+
+            // lastJoinDate 업데이트
+            memberChatroom.updateLastJoinDate(lastViewDate);
+
+            // 상대 회원의 memberChatroom의 latJoinDate가 null인 경우, 상대 회원의 lastJoinDate 업데이트
+            Chatroom chatroom = memberChatroom.getChatroom();
+
+            Member targetMember = memberChatroomRepository.findTargetMemberByChatroomIdAndMemberId(
+                chatroom.getId(), memberChatroom.getMember().getId());
+            MemberChatroom targetMemberChatroom = memberChatroomRepository.findByMemberIdAndChatroomId(
+                targetMember.getId(), chatroom.getId()).get();
+            if (targetMemberChatroom.getLastJoinDate() == null) {
+                targetMemberChatroom.updateLastJoinDate(lastViewDate);
+
+            }
+
+        } else {
+            // lastViewDate 업데이트
+            memberChatroom.updateLastViewDate(lastViewDate);
+
         }
     }
 

--- a/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
@@ -53,7 +53,6 @@ public class ChatCommandService {
         String uuid = UUID.randomUUID().toString();
         Chatroom chatroom = Chatroom.builder()
             .uuid(uuid)
-            .postUrl(request.getPostUrl())
             .startMember(member)
             .build();
 
@@ -63,6 +62,7 @@ public class ChatCommandService {
         // 나의 MemberChatroom 엔티티
         MemberChatroom memberChatroom = MemberChatroom.builder()
             .lastViewDate(null)
+            .lastJoinDate(null)
             .chatroom(chatroom)
             .build();
         memberChatroom.setMember(member);
@@ -71,10 +71,52 @@ public class ChatCommandService {
         // 상대방의 MemberChatroom 엔티티
         MemberChatroom targetMemberChatroom = MemberChatroom.builder()
             .lastViewDate(null)
+            .lastJoinDate(null)
             .chatroom(chatroom)
             .build();
         targetMemberChatroom.setMember(targetMember);
         memberChatroomRepository.save(targetMemberChatroom);
+
+        return savedChatroom;
+    }
+
+    @Transactional
+    public Chatroom createChatroomByMatch(ChatRequest.ChatroomCreateByMatchRequest request) {
+        if (request.getMemberList().size() != 2) {
+            throw new ChatHandler(ErrorStatus._BAD_REQUEST);
+        }
+        Member member1 = profileService.findMember(request.getMemberList().get(0));
+        Member member2 = profileService.findMember(request.getMemberList().get(1));
+
+        // chatroom 엔티티 생성
+        String uuid = UUID.randomUUID().toString();
+        Chatroom chatroom = Chatroom.builder()
+            .uuid(uuid)
+            .startMember(null)
+            .build();
+
+        Chatroom savedChatroom = chatroomRepository.save(chatroom);
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // MemberChatroom 엔티티 생성 및 연관관계 매핑
+        // member1의 MemberChatroom 엔티티
+        MemberChatroom memberChatroom1 = MemberChatroom.builder()
+            .lastViewDate(null)
+            .lastJoinDate(now)
+            .chatroom(chatroom)
+            .build();
+        memberChatroom1.setMember(member1);
+        memberChatroomRepository.save(memberChatroom1);
+
+        // member2의 MemberChatroom 엔티티
+        MemberChatroom memberChatroom2 = MemberChatroom.builder()
+            .lastViewDate(null)
+            .lastJoinDate(now)
+            .chatroom(chatroom)
+            .build();
+        memberChatroom2.setMember(member2);
+        memberChatroomRepository.save(memberChatroom2);
 
         return savedChatroom;
     }

--- a/src/main/java/com/gamegoo/service/chat/ChatQueryService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatQueryService.java
@@ -122,7 +122,8 @@ public class ChatQueryService {
 
         // requestParam으로 cursor가 넘어온 경우
         if (cursor != null) {
-            return chatRepository.findChatsByCursor(cursor, chatroom.getId(), pageRequest);
+            return chatRepository.findChatsByCursor(cursor, chatroom.getId(),
+                memberChatroom.getId(), pageRequest);
         } else { // cursor가 넘어오지 않은 경우 = 해당 chatroom의 가장 최근 chat을 조회하는 요청
             return chatRepository.findRecentChats(chatroom.getId(), memberChatroom.getId());
         }

--- a/src/main/java/com/gamegoo/service/chat/ChatQueryService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatQueryService.java
@@ -77,6 +77,9 @@ public class ChatQueryService {
                 if (lastChat.isPresent()) {
                     lastAtIoString = lastChat.get().getCreatedAt()
                         .format(DateTimeFormatter.ISO_DATE_TIME);
+                } else {
+                    lastAtIoString = memberChatroom.getLastJoinDate()
+                        .format(DateTimeFormatter.ISO_DATE_TIME);
                 }
 
                 return ChatResponse.ChatroomViewDTO.builder()


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
채팅방 시작, 나가기 기능 구현 및 리팩토링

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- Chatroom 엔티티에서 postUrl 삭제
- 채팅 시작 API 추가
- 채팅방 나가기 API 추가
- 채팅 메시지 읽음 처리 API  endpoint 변경
- 일반 채팅방/매칭 채팅방 직접 생성(서버 테스트용) API 추가 및 시큐리티 설정
- 채팅방 입장 결과 dto에 chatroomUuid 추가
- countUnreadChats 쿼리 메소드 변경: lastJoinDate 이후의 메시지만 count 하도록
- findRecentChats 쿼리 메소드 변경: lastJoinDate 이후의 메시지만 조회하도록
- findChatsByCursor 쿼리 메소드 변경: lastJoinDate 이후의 메시지만 조회하도록
- findChatroomByMemberIds 쿼리 메소드 추가: memberId 2개를 이용해 해당 회원 사이의 채팅방 엔티티 조회하기
- 채팅방 목록 조회 쿼리 메소드 변경: 대화 내역이 아예 없는 경우에 대한 정렬 조건 추가
- 채팅방 생성 로직 수정: updateLastViewDateByAddChat private 메소드 추가

## ⏳ 작업 내용
- [x] 채팅 시작 API 구현
- [x] 채팅방 나가기 API 구현
- [x] 채팅방 직접 생성 (서버 테스트용) API 구현
- [x] 채팅방 생성 및 나가기 기능 추가에 따른 쿼리 메소드 및 서비스 메소드 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
