### PR TITLE
[Feat/116] JWT 토큰 없이 비밀번호 재설정하는 API 만들기

### DIFF
--- a/src/main/java/com/gamegoo/config/SecurityConfig.java
+++ b/src/main/java/com/gamegoo/config/SecurityConfig.java
@@ -1,15 +1,11 @@
 package com.gamegoo.config;
 
-import static org.springframework.security.config.Customizer.withDefaults;
-
 import com.gamegoo.apiPayload.exception.handler.JWTExceptionHandlerFilter;
 import com.gamegoo.filter.JWTFilter;
 import com.gamegoo.filter.LoginFilter;
 import com.gamegoo.repository.member.MemberRepository;
 import com.gamegoo.security.CustomUserDetailService;
 import com.gamegoo.util.JWTUtil;
-import java.util.Arrays;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,6 +22,11 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
+import java.util.Arrays;
+import java.util.List;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -38,16 +39,16 @@ public class SecurityConfig {
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
-        throws Exception {
+            throws Exception {
         return configuration.getAuthenticationManager();
     }
 
     @Bean
     public JWTFilter jwtFilter() {
         List<String> excludedPaths = Arrays.asList("/swagger-ui/", "/v3/api-docs",
-            "/v1/member/join", "/v1/member/login", "/v1/member/email", "/v1/member/refresh",
-            "/v1/member/riot", "/v1/posts/list", "/v1/posts/list/{boardId}",
-            "/v1/test/chatroom/create/matched");
+                "/v1/member/join", "/v1/member/login", "/v1/member/email", "/v1/member/refresh",
+                "/v1/member/riot", "/v1/posts/list", "/v1/posts/list/{boardId}",
+                "/v1/test/chatroom/create/matched", "/v1/member/password/reset");
         return new JWTFilter(jwtUtil, excludedPaths, customUserDetailService);
 
     }
@@ -61,24 +62,24 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
 
-            .csrf(AbstractHttpConfigurer::disable)
-            .formLogin(AbstractHttpConfigurer::disable)
-            .httpBasic(AbstractHttpConfigurer::disable)
-            .cors(withDefaults())
-            .authorizeHttpRequests((auth) -> auth
-                .antMatchers("/", "/v1/member/join", "/v1/member/login", "/v1/member/email/**",
-                    "/v1/member/refresh", "/v1/member/riot", "/v1/posts/list/**",
-                    "/v1/test/chatroom/create/matched").permitAll()
-                .antMatchers("/", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                .anyRequest().authenticated())
-            .addFilterBefore(new JWTExceptionHandlerFilter(),
-                UsernamePasswordAuthenticationFilter.class)
-            .addFilterAt(
-                new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil,
-                    memberRepository), UsernamePasswordAuthenticationFilter.class)
-            .addFilterBefore(jwtFilter(), LoginFilter.class)
-            .sessionManagement((session) -> session
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .cors(withDefaults())
+                .authorizeHttpRequests((auth) -> auth
+                        .antMatchers("/", "/v1/member/join", "/v1/member/login", "/v1/member/email/**",
+                                "/v1/member/refresh", "/v1/member/riot", "/v1/posts/list/**",
+                                "/v1/test/chatroom/create/matched", "/v1/member/password/reset").permitAll()
+                        .antMatchers("/", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .anyRequest().authenticated())
+                .addFilterBefore(new JWTExceptionHandlerFilter(),
+                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterAt(
+                        new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil,
+                                memberRepository), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtFilter(), LoginFilter.class)
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return http.build();
     }

--- a/src/main/java/com/gamegoo/controller/member/PasswordController.java
+++ b/src/main/java/com/gamegoo/controller/member/PasswordController.java
@@ -23,13 +23,13 @@ public class PasswordController {
     private final PasswordService passwordService;
 
     @PostMapping("/check")
-    @Operation(summary = "비밀번호 확인 API 입니다.", description = "API for checking password")
-    public ApiResponse<String> checkPassword(
-        @RequestBody MemberRequest.PasswordRequestDTO passwordRequestDTO) {
+    @Operation(summary = "JWT 토큰이 필요한 비밀번호 확인 API 입니다.", description = "API for checking password with JWT")
+    public ApiResponse<String> checkPasswordWithJWT(
+            @RequestBody MemberRequest.PasswordRequestJWTDTO passwordRequestDTO) {
         Long currentUserId = JWTUtil.getCurrentUserId(); //헤더에 있는 jwt 토큰에서 id를 가져오는 코드
 
         boolean isPasswordValid = passwordService.checkPasswordById(currentUserId,
-            passwordRequestDTO.getPassword()); //request body에 있는 password와 currentUserId를 전달
+                passwordRequestDTO.getPassword()); //request body에 있는 password와 currentUserId를 전달
 
         if (isPasswordValid) {
             return ApiResponse.onSuccess("비밀번호가 일치합니다.");
@@ -38,13 +38,23 @@ public class PasswordController {
         }
     }
 
-    @PostMapping("/reset")
-    @Operation(summary = "비밀번호 재설정 API 입니다.", description = "API for reseting password")
-    public ApiResponse<String> resetPassword(
-        @RequestBody MemberRequest.PasswordRequestDTO passwordRequestDTO) {
+    @PostMapping("/reset/jwt")
+    @Operation(summary = "JWT 토큰이 필요한 비밀번호 재설정 API 입니다.", description = "API for reseting password with JWT")
+    public ApiResponse<String> resetPasswordWithJWT(
+            @RequestBody MemberRequest.PasswordRequestJWTDTO passwordRequestDTO) {
         Long currentUserId = JWTUtil.getCurrentUserId();
 
         passwordService.updatePassword(currentUserId, passwordRequestDTO.getPassword());
+
+        return ApiResponse.onSuccess("비밀번호 재설정을 완료했습니다.");
+    }
+
+    @PostMapping("/reset")
+    @Operation(summary = "비밀번호 재설정 API 입니다.", description = "API for reseting password")
+    public ApiResponse<String> resetPassword(
+            @RequestBody MemberRequest.PasswordRequestDTO passwordRequestDTO) {
+
+        passwordService.updatePasswordWithEmail(passwordRequestDTO.getEmail(), passwordRequestDTO.getPassword());
 
         return ApiResponse.onSuccess("비밀번호 재설정을 완료했습니다.");
     }

--- a/src/main/java/com/gamegoo/dto/member/MemberRequest.java
+++ b/src/main/java/com/gamegoo/dto/member/MemberRequest.java
@@ -55,12 +55,22 @@ public class MemberRequest {
     }
 
     @Getter
-    public static class PasswordRequestDTO {
-
+    public static class PasswordRequestJWTDTO {
         @NotBlank(message = "password는 비워둘 수 없습니다.")
         String password;
 
     }
+
+    @Getter
+    public static class PasswordRequestDTO {
+        @Email(message = "Email 형식이 올바르지 않습니다.")
+        @NotBlank(message = "Email은 비워둘 수 없습니다.")
+        String email;
+        @NotBlank(message = "password는 비워둘 수 없습니다.")
+        String password;
+
+    }
+
 
     @Getter
     public static class PositionRequestDTO {

--- a/src/main/java/com/gamegoo/service/member/PasswordService.java
+++ b/src/main/java/com/gamegoo/service/member/PasswordService.java
@@ -44,4 +44,20 @@ public class PasswordService {
         memberRepository.save(member);
     }
 
+    /**
+     * 비밀번호 수정
+     *
+     * @param email
+     * @param newPassword
+     */
+    public void updatePasswordWithEmail(String email, String newPassword) {
+        // jwt 토큰으로 멤버 찾기
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 비밀번호 재설정
+        member.updatePassword(bCryptPasswordEncoder.encode(newPassword));
+        memberRepository.save(member);
+    }
+
 }


### PR DESCRIPTION
## 🚀 개요
JWT 토큰 없이 비밀번호 재설정하는 API 개발

## 🔍 변경사항
- POST /v1/member/password/reset API 추가
- 기존 password 관련 API 뒤에 jwt 엔드포인트 추가

## ⏳ 작업 내용
- [x] 비밀번호 관련 API 엔드포인트 수정
- [x] JWT 없이 비밀번호 재설정하는 API 개발

### 📝 논의사항
