### PR TITLE
[Feat/124] 알림 등록 메소드 구현 및 친구 요청 전송 시 알림 등록

### DIFF
--- a/src/main/generated/com/gamegoo/domain/notification/QNotification.java
+++ b/src/main/generated/com/gamegoo/domain/notification/QNotification.java
@@ -37,6 +37,8 @@ public class QNotification extends EntityPathBase<Notification> {
 
     public final QNotificationType notificationType;
 
+    public final NumberPath<Long> sourceId = createNumber("sourceId", Long.class);
+
     //inherited
     public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
 

--- a/src/main/generated/com/gamegoo/domain/notification/QNotificationType.java
+++ b/src/main/generated/com/gamegoo/domain/notification/QNotificationType.java
@@ -30,9 +30,9 @@ public class QNotificationType extends EntityPathBase<NotificationType> {
 
     public final StringPath imgUrl = createString("imgUrl");
 
-    public final StringPath name = createString("name");
-
     public final StringPath sourceUrl = createString("sourceUrl");
+
+    public final EnumPath<NotificationTypeTitle> title = createEnum("title", NotificationTypeTitle.class);
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;

--- a/src/main/generated/com/gamegoo/domain/notification/QNotificationType.java
+++ b/src/main/generated/com/gamegoo/domain/notification/QNotificationType.java
@@ -32,6 +32,8 @@ public class QNotificationType extends EntityPathBase<NotificationType> {
 
     public final StringPath name = createString("name");
 
+    public final StringPath sourceUrl = createString("sourceUrl");
+
     //inherited
     public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
 

--- a/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
@@ -118,6 +118,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 알림 관련 에러
     NOTIFICATION_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI401", "잘못된 알림 타입입니다."),
+    NOTIFICATION_METHOD_BAD_REQUEST(HttpStatus.BAD_REQUEST, "NOTI402", "알림 생성 메소드 호출이 잘못되었습니다."),
 
     ;
 

--- a/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
@@ -116,6 +116,9 @@ public enum ErrorStatus implements BaseErrorCode {
     BLOCKED_BY_FRIEND_TARGET(HttpStatus.BAD_REQUEST, "FRIEND403",
         "나를 차단한 회원입니다. 친구 요청을 보낼 수 없습니다."),
 
+    // 알림 관련 에러
+    NOTIFICATION_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI401", "잘못된 알림 타입입니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/gamegoo/apiPayload/exception/handler/NotificationHandler.java
+++ b/src/main/java/com/gamegoo/apiPayload/exception/handler/NotificationHandler.java
@@ -1,0 +1,11 @@
+package com.gamegoo.apiPayload.exception.handler;
+
+import com.gamegoo.apiPayload.code.BaseErrorCode;
+import com.gamegoo.apiPayload.exception.GeneralException;
+
+public class NotificationHandler extends GeneralException {
+
+    public NotificationHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/gamegoo/controller/TestController.java
+++ b/src/main/java/com/gamegoo/controller/TestController.java
@@ -1,11 +1,18 @@
 package com.gamegoo.controller;
 
+import com.gamegoo.apiPayload.ApiResponse;
 import com.gamegoo.apiPayload.code.status.ErrorStatus;
 import com.gamegoo.apiPayload.exception.handler.TempHandler;
+import com.gamegoo.domain.Member;
+import com.gamegoo.domain.notification.NotificationTypeTitle;
+import com.gamegoo.service.member.ProfileService;
+import com.gamegoo.service.notification.NotificationService;
+import com.gamegoo.util.JWTUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,6 +21,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api")
 @Slf4j
 public class TestController {
+
+    private final NotificationService notificationService;
+    private final ProfileService profileService;
 
     @GetMapping("/test/hello")
     @Operation(summary = "swagger 테스트용 API 입니다.", description = "simple API for swagger test!")
@@ -26,5 +36,20 @@ public class TestController {
     public String apiResponseTest() {
         throw new TempHandler(ErrorStatus.TEMP_EXCEPTION);
     }
-    
+
+    @GetMapping("/test/send/notifications/{times}")
+    @Operation(summary = "테스트용 알림 생성 API 입니다.", description = "서버 테스트용 입니다!!")
+    public ApiResponse<String> sendTestNotifications(
+        @PathVariable(name = "times") int times
+    ) {
+        Long memberId = JWTUtil.getCurrentUserId();
+        Member member = profileService.findMember(memberId);
+
+        for (int i = 0; i < times; i++) {
+            notificationService.createNotification(NotificationTypeTitle.TEST_ALARM, null, null,
+                member);
+        }
+        return ApiResponse.onSuccess("테스트 알림 생성 성공");
+    }
+
 }

--- a/src/main/java/com/gamegoo/domain/notification/Notification.java
+++ b/src/main/java/com/gamegoo/domain/notification/Notification.java
@@ -2,9 +2,19 @@ package com.gamegoo.domain.notification;
 
 import com.gamegoo.domain.Member;
 import com.gamegoo.domain.common.BaseDateTimeEntity;
-import lombok.*;
-
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -12,6 +22,7 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Notification extends BaseDateTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "notification_id")
@@ -21,7 +32,9 @@ public class Notification extends BaseDateTimeEntity {
     private String content;
 
     @Column(nullable = false)
-    private Boolean isRead;
+    private boolean isRead;
+
+    private Long sourceId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/com/gamegoo/domain/notification/Notification.java
+++ b/src/main/java/com/gamegoo/domain/notification/Notification.java
@@ -44,4 +44,13 @@ public class Notification extends BaseDateTimeEntity {
     @JoinColumn(name = "notification_type_id", nullable = false)
     private NotificationType notificationType;
 
+    // 연관관계 메소드
+    public void setMember(Member member) {
+        if (this.member != null) {
+            this.member.getNotificationList().remove(this);
+        }
+        this.member = member;
+        this.member.getNotificationList().add(this);
+    }
+
 }

--- a/src/main/java/com/gamegoo/domain/notification/NotificationType.java
+++ b/src/main/java/com/gamegoo/domain/notification/NotificationType.java
@@ -1,9 +1,16 @@
 package com.gamegoo.domain.notification;
 
 import com.gamegoo.domain.common.BaseDateTimeEntity;
-import lombok.*;
-
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -11,6 +18,7 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class NotificationType extends BaseDateTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "notification_type_id")
@@ -24,6 +32,8 @@ public class NotificationType extends BaseDateTimeEntity {
 
     @Column(nullable = false, length = 200)
     private String imgUrl;
+    
+    private String sourceUrl;
 
 
 }

--- a/src/main/java/com/gamegoo/domain/notification/NotificationType.java
+++ b/src/main/java/com/gamegoo/domain/notification/NotificationType.java
@@ -3,6 +3,8 @@ package com.gamegoo.domain.notification;
 import com.gamegoo.domain.common.BaseDateTimeEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -24,16 +26,16 @@ public class NotificationType extends BaseDateTimeEntity {
     @Column(name = "notification_type_id")
     private Long id;
 
-    @Column(nullable = false, length = 30)
-    private String name;
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(30)", nullable = false)
+    private NotificationTypeTitle title;
 
     @Column(nullable = false, length = 400)
     private String content;
 
     @Column(nullable = false, length = 200)
     private String imgUrl;
-    
-    private String sourceUrl;
 
+    private String sourceUrl;
 
 }

--- a/src/main/java/com/gamegoo/domain/notification/NotificationTypeTitle.java
+++ b/src/main/java/com/gamegoo/domain/notification/NotificationTypeTitle.java
@@ -7,7 +7,9 @@ public enum NotificationTypeTitle {
     FRIEND_REQUEST_REJECTED("님이 친구를 거절했어요.", null),
     MANNER_LEVEL_UP("매너레벨이 n단계로 올라갔어요!", "/member/manner"),
     MANNER_LEVEL_DOWN("매너레벨이 n단계로 떨어졌어요.", "/member/manner"),
-    MANNER_KEYWORD_RATED("지난 매칭에서 n 키워드를 받았어요.", "/member/manner");
+    MANNER_KEYWORD_RATED("지난 매칭에서 n 키워드를 받았어요.", "/member/manner"),
+    TEST_ALARM("TEST PUSH. NUMBER: ", null),
+    ;
 
     private final String content;
     private final String sourceUrl;

--- a/src/main/java/com/gamegoo/domain/notification/NotificationTypeTitle.java
+++ b/src/main/java/com/gamegoo/domain/notification/NotificationTypeTitle.java
@@ -1,0 +1,27 @@
+package com.gamegoo.domain.notification;
+
+public enum NotificationTypeTitle {
+    FRIEND_REQUEST_SEND("님에게 친구 요청을 보냈어요.", null),
+    FRIEND_REQUEST_RECEIVED("님에게 친구 요청이 왔어요.", "/member/profile/"),
+    FRIEND_REQUEST_ACCEPTED("님이 친구를 수락했어요.", null),
+    FRIEND_REQUEST_REJECTED("님이 친구를 거절했어요.", null),
+    MANNER_LEVEL_UP("매너레벨이 n단계로 올라갔어요!", "/member/manner"),
+    MANNER_LEVEL_DOWN("매너레벨이 n단계로 떨어졌어요.", "/member/manner"),
+    MANNER_KEYWORD_RATED("지난 매칭에서 n 키워드를 받았어요.", "/member/manner");
+
+    private final String content;
+    private final String sourceUrl;
+
+    NotificationTypeTitle(String content, String sourceUrl) {
+        this.content = content;
+        this.sourceUrl = sourceUrl;
+    }
+
+    public String getMessage() {
+        return content;
+    }
+
+    public String getSourceUrl() {
+        return sourceUrl;
+    }
+}

--- a/src/main/java/com/gamegoo/repository/notification/NotificationRepository.java
+++ b/src/main/java/com/gamegoo/repository/notification/NotificationRepository.java
@@ -1,0 +1,8 @@
+package com.gamegoo.repository.notification;
+
+import com.gamegoo.domain.notification.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/src/main/java/com/gamegoo/repository/notification/NotificationTypeRepository.java
+++ b/src/main/java/com/gamegoo/repository/notification/NotificationTypeRepository.java
@@ -1,0 +1,12 @@
+package com.gamegoo.repository.notification;
+
+import com.gamegoo.domain.notification.NotificationType;
+import com.gamegoo.domain.notification.NotificationTypeTitle;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationTypeRepository extends JpaRepository<NotificationType, Long> {
+
+    Optional<NotificationType> findNotificationTypeByTitle(NotificationTypeTitle title);
+
+}

--- a/src/main/java/com/gamegoo/service/member/FriendService.java
+++ b/src/main/java/com/gamegoo/service/member/FriendService.java
@@ -6,8 +6,10 @@ import com.gamegoo.domain.Member;
 import com.gamegoo.domain.friend.Friend;
 import com.gamegoo.domain.friend.FriendRequestStatus;
 import com.gamegoo.domain.friend.FriendRequests;
+import com.gamegoo.domain.notification.NotificationTypeTitle;
 import com.gamegoo.repository.friend.FriendRepository;
 import com.gamegoo.repository.friend.FriendRequestsRepository;
+import com.gamegoo.service.notification.NotificationService;
 import com.gamegoo.util.MemberUtils;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ public class FriendService {
     private final FriendRepository friendRepository;
     private final FriendRequestsRepository friendRequestsRepository;
     private final ProfileService profileService;
+    private final NotificationService notificationService;
 
     /**
      * memberId에 해당하는 회원의 친구 목록 조회
@@ -47,6 +50,7 @@ public class FriendService {
 
         Member targetMember = profileService.findMember(targetMemberId);
 
+        // targetMember로 나 자신을 요청한 경우
         if (member.equals(targetMember)) {
             throw new FriendHandler(ErrorStatus.FRIEND_BAD_REQUEST);
         }
@@ -67,6 +71,17 @@ public class FriendService {
             .toMember(targetMember)
             .build();
 
-        return friendRequestsRepository.save(friendRequests);
+        FriendRequests savedFriendRequests = friendRequestsRepository.save(friendRequests);
+
+        // 친구 요청 알림 생성
+        // member -> targetMember
+        notificationService.createNotification(NotificationTypeTitle.FRIEND_REQUEST_SEND,
+            targetMember.getGameName(), null, member);
+
+        // targetMember -> member
+        notificationService.createNotification(NotificationTypeTitle.FRIEND_REQUEST_RECEIVED,
+            member.getGameName(), member.getId(), targetMember);
+
+        return savedFriendRequests;
     }
 }

--- a/src/main/java/com/gamegoo/service/notification/NotificationService.java
+++ b/src/main/java/com/gamegoo/service/notification/NotificationService.java
@@ -9,6 +9,7 @@ import com.gamegoo.domain.notification.NotificationType;
 import com.gamegoo.domain.notification.NotificationTypeTitle;
 import com.gamegoo.repository.notification.NotificationRepository;
 import com.gamegoo.repository.notification.NotificationTypeRepository;
+import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -56,7 +57,12 @@ public class NotificationService {
             case MANNER_KEYWORD_RATED:
                 return createMannerKeywordRatedNotification(notificationType, content, member);
             case TEST_ALARM:
-                return createTestNotification(notificationType, content, member);
+                // 랜덤 숫자 생성
+                Random random = new Random();
+                int i = random.nextInt(1000) + 1;
+                // 숫자를 String 형으로 변환
+                String randomNumberString = Integer.toString(i);
+                return createTestNotification(notificationType, randomNumberString, member);
             default:
                 throw new NotificationHandler(ErrorStatus.NOTIFICATION_TYPE_NOT_FOUND);
         }

--- a/src/main/java/com/gamegoo/service/notification/NotificationService.java
+++ b/src/main/java/com/gamegoo/service/notification/NotificationService.java
@@ -41,6 +41,9 @@ public class NotificationService {
             case FRIEND_REQUEST_SEND:
                 return createFriendRequestSendNotification(notificationType, content, member);
             case FRIEND_REQUEST_RECEIVED:
+                if (sourceId == null) {
+                    throw new NotificationHandler(ErrorStatus.NOTIFICATION_METHOD_BAD_REQUEST);
+                }
                 return createFriendRequestReceivedNotification(notificationType, content, sourceId,
                     member);
             case FRIEND_REQUEST_ACCEPTED:

--- a/src/main/java/com/gamegoo/service/notification/NotificationService.java
+++ b/src/main/java/com/gamegoo/service/notification/NotificationService.java
@@ -55,6 +55,8 @@ public class NotificationService {
                 return createMannerLevelUpDownNotification(notificationType, content, member);
             case MANNER_KEYWORD_RATED:
                 return createMannerKeywordRatedNotification(notificationType, content, member);
+            case TEST_ALARM:
+                return createTestNotification(notificationType, content, member);
             default:
                 throw new NotificationHandler(ErrorStatus.NOTIFICATION_TYPE_NOT_FOUND);
         }
@@ -162,6 +164,26 @@ public class NotificationService {
         Notification notification = Notification.builder()
             .notificationType(notificationType)
             .content(notificationContent)
+            .isRead(false)
+            .build();
+        notification.setMember(member);
+
+        return notificationRepository.save(notification);
+    }
+
+    /**
+     * 테스트 알림 생성
+     *
+     * @param notificationType
+     * @param content
+     * @param member
+     * @return
+     */
+    private Notification createTestNotification(NotificationType notificationType, String content,
+        Member member) {
+        Notification notification = Notification.builder()
+            .notificationType(notificationType)
+            .content(notificationType.getContent() + content)
             .isRead(false)
             .build();
         notification.setMember(member);

--- a/src/main/java/com/gamegoo/service/notification/NotificationService.java
+++ b/src/main/java/com/gamegoo/service/notification/NotificationService.java
@@ -26,9 +26,9 @@ public class NotificationService {
      * 새로운 알림 생성 및 저장 메소드
      *
      * @param notificationTypeTitle
-     * @param content
-     * @param sourceId
-     * @param member
+     * @param content               각 알림에 포함되어어야 할 정보 (사용자 닉네임, 매너레벨 단계, 키둬드)
+     * @param sourceId              이동해야할 url의 고유 id 파라미터, FRIEND_REQUEST_RECEIVED에서만 필요
+     * @param member                알림을 받을 대상 회원
      * @return
      */
     public Notification createNotification(NotificationTypeTitle notificationTypeTitle,

--- a/src/main/java/com/gamegoo/service/notification/NotificationService.java
+++ b/src/main/java/com/gamegoo/service/notification/NotificationService.java
@@ -1,0 +1,169 @@
+package com.gamegoo.service.notification;
+
+
+import com.gamegoo.apiPayload.code.status.ErrorStatus;
+import com.gamegoo.apiPayload.exception.handler.NotificationHandler;
+import com.gamegoo.domain.Member;
+import com.gamegoo.domain.notification.Notification;
+import com.gamegoo.domain.notification.NotificationType;
+import com.gamegoo.domain.notification.NotificationTypeTitle;
+import com.gamegoo.repository.notification.NotificationRepository;
+import com.gamegoo.repository.notification.NotificationTypeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationService {
+
+    private final NotificationTypeRepository notificationTypeRepository;
+    private final NotificationRepository notificationRepository;
+
+    /**
+     * 새로운 알림 생성 및 저장 메소드
+     *
+     * @param notificationTypeTitle
+     * @param content
+     * @param sourceId
+     * @param member
+     * @return
+     */
+    public Notification createNotification(NotificationTypeTitle notificationTypeTitle,
+        String content, Long sourceId, Member member) {
+
+        NotificationType notificationType = notificationTypeRepository.findNotificationTypeByTitle(
+                notificationTypeTitle)
+            .orElseThrow(() -> new NotificationHandler(ErrorStatus.NOTIFICATION_TYPE_NOT_FOUND));
+
+        switch (notificationTypeTitle) {
+            case FRIEND_REQUEST_SEND:
+                return createFriendRequestSendNotification(notificationType, content, member);
+            case FRIEND_REQUEST_RECEIVED:
+                return createFriendRequestReceivedNotification(notificationType, content, sourceId,
+                    member);
+            case FRIEND_REQUEST_ACCEPTED:
+            case FRIEND_REQUEST_REJECTED:
+                return createFriendRequestAcceptedAndRejectedNotification(notificationType, content,
+                    member);
+            case MANNER_LEVEL_UP:
+            case MANNER_LEVEL_DOWN:
+                return createMannerLevelUpDownNotification(notificationType, content, member);
+            case MANNER_KEYWORD_RATED:
+                return createMannerKeywordRatedNotification(notificationType, content, member);
+            default:
+                throw new NotificationHandler(ErrorStatus.NOTIFICATION_TYPE_NOT_FOUND);
+        }
+    }
+
+    /**
+     * 친구 요청 전송됨 알림 생성
+     *
+     * @param notificationType
+     * @param content
+     * @param member
+     * @return
+     */
+    private Notification createFriendRequestSendNotification(
+        NotificationType notificationType,
+        String content, Member member) {
+        Notification notification = Notification.builder()
+            .notificationType(notificationType)
+            .content(content + notificationType.getContent())
+            .isRead(false)
+            .build();
+        notification.setMember(member);
+
+        return notificationRepository.save(notification);
+    }
+
+    /**
+     * 친구 요청 받음 알림 생성
+     *
+     * @param notificationType
+     * @param content
+     * @param sourceId
+     * @param member
+     * @return
+     */
+    private Notification createFriendRequestReceivedNotification(
+        NotificationType notificationType,
+        String content, Long sourceId, Member member
+    ) {
+        Notification notification = Notification.builder()
+            .notificationType(notificationType)
+            .content(content + notificationType.getContent())
+            .sourceId(sourceId)
+            .isRead(false)
+            .build();
+        notification.setMember(member);
+
+        return notificationRepository.save(notification);
+    }
+
+    /**
+     * 친구 요청 수락됨, 거절됨 알림 생성
+     *
+     * @param notificationType
+     * @param content
+     * @param member
+     * @return
+     */
+    private Notification createFriendRequestAcceptedAndRejectedNotification(
+        NotificationType notificationType,
+        String content, Member member
+    ) {
+        Notification notification = Notification.builder()
+            .notificationType(notificationType)
+            .content(content + notificationType.getContent())
+            .isRead(false)
+            .build();
+        notification.setMember(member);
+
+        return notificationRepository.save(notification);
+    }
+
+    /**
+     * 매너레벨 상승, 하락 알림 생성
+     *
+     * @param notificationType
+     * @param content
+     * @param member
+     * @return
+     */
+    private Notification createMannerLevelUpDownNotification(NotificationType notificationType,
+        String content, Member member) {
+        String notificationContent = notificationType.getContent().replace("n", content);
+        Notification notification = Notification.builder()
+            .notificationType(notificationType)
+            .content(notificationContent)
+            .isRead(false)
+            .build();
+        notification.setMember(member);
+
+        return notificationRepository.save(notification);
+    }
+
+    /**
+     * 키워드 평가 알림 생성
+     *
+     * @param notificationType
+     * @param content
+     * @param member
+     * @return
+     */
+    private Notification createMannerKeywordRatedNotification(NotificationType notificationType,
+        String content, Member member) {
+        String notificationContent = notificationType.getContent().replace("n", content);
+        Notification notification = Notification.builder()
+            .notificationType(notificationType)
+            .content(notificationContent)
+            .isRead(false)
+            .build();
+        notification.setMember(member);
+
+        return notificationRepository.save(notification);
+    }
+
+}


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
알림 등록 메소드 구현 및 친구 요청 전송 시 알림 등록

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- Notification 엔티티에 sourceId 추가
- NotificationTypeTitle enum 추가
- NotificationType 엔티티에 sourceUrl, title 칼럼 추가
- 알림 등록 서비스 메소드 추가
- 친구 요청 전송 시, 나와 대상 회원에게 각 type에 맞는 알림 등록

## ⏳ 작업 내용
- [x] Notification, NotificationType 엔티티 수정
- [x] NotificationTypeTitle enum 추가
- [x] 알림 등록 서비스 메소드 구현
- [x] 친구 요청 전송 로직 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
노션 API 명세서 아래 서비스 메소드 명세에 알림 등록 서비스 메소드 명세 추가했습니다.
