### PR TITLE
[Refactor/126] 회원 차단 관련 로직 추가

### DIFF
--- a/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
@@ -108,6 +108,10 @@ public enum ErrorStatus implements BaseErrorCode {
         "채팅 상대 회원을 차단한 상태입니다. 채팅 시작이 불가능합니다."),
     BLOCKED_BY_CHAT_TARGET_CHAT_START_FAILED(HttpStatus.FORBIDDEN, "CHAT406",
         "채팅 상대 회원이 나를 차단했습니다. 채팅 시작이 불가능합니다."),
+    CHAT_TARGET_IS_BLOCKED_SEND_CHAT_FAILED(HttpStatus.FORBIDDEN, "CHAT407",
+        "채팅 상대 회원을 차단한 상태입니다. 채팅 메시지 전송이 불가능합니다."),
+    BLOCKED_BY_CHAT_TARGET_SEND_CHAT_FAILED(HttpStatus.FORBIDDEN, "CHAT408",
+        "채팅 상대 회원이 나를 차단했습니다. 채팅 메시지 전송이 불가능합니다."),
 
     // 친구 관련 에러
     FRIEND_BAD_REQUEST(HttpStatus.BAD_REQUEST, "FRIEND401", "잘못된 친구 요청입니다."),

--- a/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
@@ -108,6 +108,10 @@ public enum ErrorStatus implements BaseErrorCode {
     CHATROOM_NOT_EXIST(HttpStatus.NOT_FOUND, "CHAT402", "채팅방을 찾을 수 없습니다."),
     CHATROOM_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "CHAT403", "접근할 수 없는 채팅방 입니다."),
     CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT404", "해당 메시지를 찾을 수 없습니다"),
+    CHAT_TARGET_IS_BLOCKED_CHAT_START_FAILED(HttpStatus.FORBIDDEN, "CHAT405",
+        "채팅 상대 회원을 차단한 상태입니다. 채팅 시작이 불가능합니다."),
+    BLOCKED_BY_CHAT_TARGET_CHAT_START_FAILED(HttpStatus.FORBIDDEN, "CHAT406",
+        "채팅 상대 회원이 나를 차단했습니다. 채팅 시작이 불가능합니다."),
 
     // 친구 관련 에러
     FRIEND_BAD_REQUEST(HttpStatus.BAD_REQUEST, "FRIEND401", "잘못된 친구 요청입니다."),

--- a/src/main/java/com/gamegoo/domain/friend/FriendRequests.java
+++ b/src/main/java/com/gamegoo/domain/friend/FriendRequests.java
@@ -41,4 +41,8 @@ public class FriendRequests extends BaseDateTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "to_member_id", nullable = false)
     private Member toMember;
+
+    public void updateStatus(FriendRequestStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
+++ b/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
@@ -45,6 +45,7 @@ public class ChatResponse {
         Long memberId;
         String gameName;
         String memberProfileImg;
+        boolean isBlocked;
         ChatMessageListDTO chatMessageList;
 
     }

--- a/src/main/java/com/gamegoo/repository/friend/FriendRepository.java
+++ b/src/main/java/com/gamegoo/repository/friend/FriendRepository.java
@@ -1,10 +1,14 @@
 package com.gamegoo.repository.friend;
 
+import com.gamegoo.domain.Member;
 import com.gamegoo.domain.friend.Friend;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     List<Friend> findAllByFromMemberId(Long memberId);
+
+    Optional<Friend> findByFromMemberAndToMember(Member fromMember, Member toMember);
 }

--- a/src/main/java/com/gamegoo/repository/friend/FriendRequestsRepository.java
+++ b/src/main/java/com/gamegoo/repository/friend/FriendRequestsRepository.java
@@ -1,8 +1,14 @@
 package com.gamegoo.repository.friend;
 
+import com.gamegoo.domain.Member;
+import com.gamegoo.domain.friend.FriendRequestStatus;
 import com.gamegoo.domain.friend.FriendRequests;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FriendRequestsRepository extends JpaRepository<FriendRequests, Long> {
+
+    Optional<FriendRequests> findByFromMemberAndToMemberAndStatus(Member fromMember,
+        Member toMember, FriendRequestStatus status);
 
 }

--- a/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
@@ -52,7 +52,7 @@ public class ChatCommandService {
             .orElseThrow(() -> new ChatHandler(ErrorStatus.CHAT_TARGET_NOT_FOUND));
 
         // 내가 채팅 대상 회원을 차단한 경우
-        if (MemberUtils.isBocked(member, targetMember)) {
+        if (MemberUtils.isBlocked(member, targetMember)) {
             throw new ChatHandler(ErrorStatus.CHAT_TARGET_IS_BLOCKED_CHAT_START_FAILED);
         }
 
@@ -67,7 +67,7 @@ public class ChatCommandService {
                 .orElseThrow(() -> new ChatHandler(ErrorStatus.CHATROOM_ACCESS_DENIED));
 
             // 채팅 대상 회원이 나를 차단함 && 내가 해당 채팅방을 퇴장한 상태인 경우
-            if (MemberUtils.isBocked(targetMember, member)
+            if (MemberUtils.isBlocked(targetMember, member)
                 && memberChatroom.getLastJoinDate() == null) {
                 throw new ChatHandler(ErrorStatus.BLOCKED_BY_CHAT_TARGET_CHAT_START_FAILED);
             }
@@ -88,11 +88,12 @@ public class ChatCommandService {
                 .memberId(targetMember.getId())
                 .gameName(targetMember.getGameName())
                 .memberProfileImg(targetMember.getProfileImage())
+                .isBlocked(MemberUtils.isBlocked(targetMember, member))
                 .chatMessageList(chatMessageListDTO)
                 .build();
         } else {
             // 채팅 상대 회원이 나를 차단한 경우
-            if (MemberUtils.isBocked(targetMember, member)) {
+            if (MemberUtils.isBlocked(targetMember, member)) {
                 throw new ChatHandler(ErrorStatus.BLOCKED_BY_CHAT_TARGET_CHAT_START_FAILED);
             }
 
@@ -130,6 +131,7 @@ public class ChatCommandService {
                 .memberId(targetMember.getId())
                 .gameName(targetMember.getGameName())
                 .memberProfileImg(targetMember.getProfileImage())
+                .isBlocked(false)
                 .chatMessageList(null)
                 .build();
         }
@@ -251,8 +253,14 @@ public class ChatCommandService {
             chatroom.getId(), memberId);
 
         // 내가 채팅 상대 회원을 차단한 경우
-        if (MemberUtils.isBocked(member, targetMember)) {
+        if (MemberUtils.isBlocked(member, targetMember)) {
             throw new ChatHandler(ErrorStatus.CHAT_TARGET_IS_BLOCKED_CHAT_START_FAILED);
+        }
+
+        // 상대방이 나를 차단 && 내가 이 채팅방을 나간 상태인 경우
+        if (MemberUtils.isBlocked(targetMember, member)
+            && memberChatroom.getLastJoinDate() == null) {
+            throw new ChatHandler(ErrorStatus.BLOCKED_BY_CHAT_TARGET_CHAT_START_FAILED);
         }
 
         // 최근 메시지 내역 조회
@@ -271,6 +279,7 @@ public class ChatCommandService {
             .memberId(targetMember.getId())
             .gameName(targetMember.getGameName())
             .memberProfileImg(targetMember.getProfileImage())
+            .isBlocked(MemberUtils.isBlocked(targetMember, member))
             .chatMessageList(chatMessageListDTO)
             .build();
     }

--- a/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
@@ -304,6 +304,17 @@ public class ChatCommandService {
                 memberId, chatroom.getId())
             .orElseThrow(() -> new ChatHandler(ErrorStatus.CHATROOM_ACCESS_DENIED));
 
+        // 회원 간 차단 여부 검증
+        // 대화 상대 회원 조회
+        Member targetMember = memberChatroomRepository.findTargetMemberByChatroomIdAndMemberId(
+            chatroom.getId(), memberId);
+        if (MemberUtils.isBlocked(member, targetMember)) {
+            throw new ChatHandler(ErrorStatus.CHAT_TARGET_IS_BLOCKED_SEND_CHAT_FAILED);
+        }
+        if (MemberUtils.isBlocked(targetMember, member)) {
+            throw new ChatHandler(ErrorStatus.BLOCKED_BY_CHAT_TARGET_SEND_CHAT_FAILED);
+        }
+
         // chat 엔티티 생성
         Chat chat = Chat.builder()
             .contents(request.getMessage())

--- a/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
@@ -15,6 +15,7 @@ import com.gamegoo.repository.chat.ChatroomRepository;
 import com.gamegoo.repository.chat.MemberChatroomRepository;
 import com.gamegoo.repository.member.MemberRepository;
 import com.gamegoo.service.member.ProfileService;
+import com.gamegoo.util.MemberUtils;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
@@ -50,6 +51,11 @@ public class ChatCommandService {
         Member targetMember = memberRepository.findById(request.getTargetMemberId())
             .orElseThrow(() -> new ChatHandler(ErrorStatus.CHAT_TARGET_NOT_FOUND));
 
+        // 내가 채팅 대상 회원을 차단한 경우
+        if (MemberUtils.isBocked(member, targetMember)) {
+            throw new ChatHandler(ErrorStatus.CHAT_TARGET_IS_BLOCKED_CHAT_START_FAILED);
+        }
+
         // 채팅 대상 회원과의 chatroom 존재 여부 조회
         Optional<Chatroom> chatroom = chatroomRepository.findChatroomByMemberIds(
             member.getId(), targetMember.getId());
@@ -59,6 +65,12 @@ public class ChatCommandService {
             MemberChatroom memberChatroom = memberChatroomRepository.findByMemberIdAndChatroomId(
                     member.getId(), chatroom.get().getId())
                 .orElseThrow(() -> new ChatHandler(ErrorStatus.CHATROOM_ACCESS_DENIED));
+
+            // 채팅 대상 회원이 나를 차단함 && 내가 해당 채팅방을 퇴장한 상태인 경우
+            if (MemberUtils.isBocked(targetMember, member)
+                && memberChatroom.getLastJoinDate() == null) {
+                throw new ChatHandler(ErrorStatus.BLOCKED_BY_CHAT_TARGET_CHAT_START_FAILED);
+            }
 
             // 최근 메시지 내역 조회
             Slice<Chat> recentChats = chatRepository.findRecentChats(chatroom.get().getId(),
@@ -79,6 +91,11 @@ public class ChatCommandService {
                 .chatMessageList(chatMessageListDTO)
                 .build();
         } else {
+            // 채팅 상대 회원이 나를 차단한 경우
+            if (MemberUtils.isBocked(targetMember, member)) {
+                throw new ChatHandler(ErrorStatus.BLOCKED_BY_CHAT_TARGET_CHAT_START_FAILED);
+            }
+
             // 기존에 채팅방이 존재하지 않는 경우: 새 채팅방 생성
             // chatroom 엔티티 생성
             String uuid = UUID.randomUUID().toString();
@@ -219,6 +236,8 @@ public class ChatCommandService {
      */
     @Transactional
     public ChatResponse.ChatroomEnterDTO enterChatroom(String chatroomUuid, Long memberId) {
+        Member member = profileService.findMember(memberId);
+
         // chatroom 엔티티 조회 및 해당 회원의 채팅방이 맞는지 검증
         Chatroom chatroom = chatroomRepository.findByUuid(chatroomUuid)
             .orElseThrow(() -> new ChatHandler(ErrorStatus.CHATROOM_NOT_EXIST));
@@ -227,11 +246,14 @@ public class ChatCommandService {
                 memberId, chatroom.getId())
             .orElseThrow(() -> new ChatHandler(ErrorStatus.CHATROOM_ACCESS_DENIED));
 
-        // 해당 회원이 퇴장한 채팅방은 아닌지도 나중에 검증 추가하기
-
-        // 채팅 상대 회원 정보 조회
+        // 채팅 상대 회원 조회
         Member targetMember = memberChatroomRepository.findTargetMemberByChatroomIdAndMemberId(
             chatroom.getId(), memberId);
+
+        // 내가 채팅 상대 회원을 차단한 경우
+        if (MemberUtils.isBocked(member, targetMember)) {
+            throw new ChatHandler(ErrorStatus.CHAT_TARGET_IS_BLOCKED_CHAT_START_FAILED);
+        }
 
         // 최근 메시지 내역 조회
         Slice<Chat> recentChats = chatRepository.findRecentChats(chatroom.getId(),
@@ -338,6 +360,12 @@ public class ChatCommandService {
 
     }
 
+    /**
+     * 채팅 등록 시 나와 상대방의 lastViewDate 업데이트
+     *
+     * @param memberChatroom
+     * @param lastViewDate
+     */
     private void updateLastViewDateByAddChat(MemberChatroom memberChatroom,
         LocalDateTime lastViewDate) {
         // lastJoinDate가 null인 경우

--- a/src/main/java/com/gamegoo/service/chat/ChatQueryService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatQueryService.java
@@ -49,7 +49,6 @@ public class ChatQueryService {
      * @param memberId
      * @return
      */
-    @Transactional(readOnly = true)
     public List<ChatResponse.ChatroomViewDTO> getChatroomList(Long memberId) {
         Member member = profileService.findMember(memberId);
 
@@ -99,7 +98,6 @@ public class ChatQueryService {
      * @param cursor
      * @return
      */
-    @Transactional(readOnly = true)
     public Slice<Chat> getChatMessagesByCursor(String chatroomUuid, Long memberId, Long cursor) {
         Member member = profileService.findMember(memberId);
 
@@ -122,6 +120,17 @@ public class ChatQueryService {
         } else { // cursor가 넘어오지 않은 경우 = 해당 chatroom의 가장 최근 chat을 조회하는 요청
             return chatRepository.findRecentChats(chatroom.getId(), memberChatroom.getId());
         }
+    }
+
+    /**
+     * 두 회원 간의 Chatroom 엔티티 반환
+     *
+     * @param member1
+     * @param member2
+     * @return
+     */
+    public Optional<Chatroom> getChatroomByMembers(Member member1, Member member2) {
+        return chatroomRepository.findChatroomByMemberIds(member1.getId(), member2.getId());
     }
 
 

--- a/src/main/java/com/gamegoo/service/member/BlockService.java
+++ b/src/main/java/com/gamegoo/service/member/BlockService.java
@@ -8,6 +8,8 @@ import com.gamegoo.domain.Block;
 import com.gamegoo.domain.Member;
 import com.gamegoo.repository.member.BlockRepository;
 import com.gamegoo.repository.member.MemberRepository;
+import com.gamegoo.service.chat.ChatCommandService;
+import com.gamegoo.service.chat.ChatQueryService;
 import com.gamegoo.util.MemberUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -22,6 +24,10 @@ public class BlockService {
 
     private final MemberRepository memberRepository;
     private final BlockRepository blockRepository;
+    private final ProfileService profileService;
+    private final ChatQueryService chatQueryService;
+    private final ChatCommandService chatCommandService;
+    private final FriendService friendService;
 
     Integer pageSize = 9;
 
@@ -33,11 +39,9 @@ public class BlockService {
      * @return
      */
     public Member blockMember(Long memberId, Long targetMemberId) {
-        // member에 대한 검증
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-        Member targetMember = memberRepository.findById(targetMemberId)
-            .orElseThrow(() -> new MemberHandler(ErrorStatus.TARGET_MEMBER_NOT_FOUND));
+        // member 엔티티 조회
+        Member member = profileService.findMember(memberId);
+        Member targetMember = profileService.findMember(targetMemberId);
 
         // 본인이 본인을 차단 시도하는 경우
         if (member.equals(targetMember)) {
@@ -62,6 +66,18 @@ public class BlockService {
 
         blockRepository.save(block);
 
+        // 차단 대상 회원과의 채팅방이 존재하는 경우, 해당 채팅방 퇴장 처리
+        chatQueryService.getChatroomByMembers(member, targetMember).ifPresent(chatroom -> {
+            // 채팅방 퇴장 처리
+            chatCommandService.exitChatroom(chatroom.getUuid(), member.getId());
+        });
+
+        // 차단 대상 회원과 친구관계인 경우, 친구 관계 끊기
+        friendService.removeFriendshipIfPresent(member, targetMember);
+
+        // 차단 대상 회원에게 보냈던 친구 요청이 있는 경우, 해당 요청 취소 처리
+        friendService.cancelPendingFriendRequests(member, targetMember);
+
         return member;
     }
 
@@ -80,8 +96,8 @@ public class BlockService {
         }
 
         // member 엔티티 조회
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        Member member = profileService.findMember(memberId);
+
         PageRequest pageRequest = PageRequest.of(pageIdx, pageSize);
 
         return memberRepository.findBlockedMembersByBlockerIdAndNotBlind(member.getId(),
@@ -95,11 +111,9 @@ public class BlockService {
      * @param targetMemberId
      */
     public void unBlockMember(Long memberId, Long targetMemberId) {
-        // member에 대한 검증
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-        Member targetMember = memberRepository.findById(targetMemberId)
-            .orElseThrow(() -> new MemberHandler(ErrorStatus.TARGET_MEMBER_NOT_FOUND));
+        // member 엔티티 조회
+        Member member = profileService.findMember(memberId);
+        Member targetMember = profileService.findMember(targetMemberId);
 
         // targetMember가 차단 실제로 차단 목록에 존재하는지 검증
         Block block = blockRepository.findByBlockerMemberAndBlockedMember(member, targetMember)

--- a/src/main/java/com/gamegoo/service/member/FriendService.java
+++ b/src/main/java/com/gamegoo/service/member/FriendService.java
@@ -52,12 +52,12 @@ public class FriendService {
         }
 
         // 내가 상대방을 차단한 경우
-        if (MemberUtils.isBocked(member, targetMember)) {
+        if (MemberUtils.isBlocked(member, targetMember)) {
             throw new FriendHandler(ErrorStatus.FRIEND_TARGET_IS_BLOCKED);
         }
 
         // 상대방이 나를 차단한 경우
-        if (MemberUtils.isBocked(targetMember, member)) {
+        if (MemberUtils.isBlocked(targetMember, member)) {
             throw new FriendHandler(ErrorStatus.BLOCKED_BY_FRIEND_TARGET);
         }
 

--- a/src/main/java/com/gamegoo/service/member/FriendService.java
+++ b/src/main/java/com/gamegoo/service/member/FriendService.java
@@ -69,4 +69,32 @@ public class FriendService {
 
         return friendRequestsRepository.save(friendRequests);
     }
+
+    /**
+     * fromMember와 toMember가 서로 친구 관계이면, 친구 관계 끊기
+     *
+     * @param fromMember
+     * @param toMember
+     */
+    public void removeFriendshipIfPresent(Member fromMember, Member toMember) {
+        friendRepository.findByFromMemberAndToMember(fromMember, toMember)
+            .ifPresent(friend -> {
+                friendRepository.deleteById(friend.getId());
+                friendRepository.findByFromMemberAndToMember(toMember, fromMember)
+                    .ifPresent(reverseFriend -> friendRepository.deleteById(reverseFriend.getId()));
+            });
+    }
+
+    /**
+     * fromMember -> toMember의 FriendRequest 중 PENDING 상태인 요청을 취소 처리
+     *
+     * @param fromMember
+     * @param toMember
+     */
+    public void cancelPendingFriendRequests(Member fromMember, Member toMember) {
+        friendRequestsRepository.findByFromMemberAndToMemberAndStatus(fromMember, toMember,
+                FriendRequestStatus.PENDING)
+            .ifPresent(
+                friendRequests -> friendRequests.updateStatus(FriendRequestStatus.CANCELLED));
+    }
 }

--- a/src/main/java/com/gamegoo/util/MemberUtils.java
+++ b/src/main/java/com/gamegoo/util/MemberUtils.java
@@ -13,7 +13,7 @@ public class MemberUtils {
      * @param targetMember
      * @return
      */
-    public static boolean isBocked(Member member, Member targetMember) {
+    public static boolean isBlocked(Member member, Member targetMember) {
 
         return member.getBlockList().stream()
             .anyMatch(block -> block.getBlockedMember().equals(targetMember));


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
채팅, 친구 관련 기능들에서 회원 차단을 고려한 로직 추가

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 회원 차단 시 해당 채팅방 나가지도록 로직 추가
- 회원 차단 시 기존 친구관계 양방향으로 끊어지도록 로직 추가
- 회원 차단 시 상대방에게 보냈던 친구 요청이 있다면 그게 취소되도록 로직 추가
- 채팅방 시작 API: 차단한/차단 당한 회원과 채팅방 시작 불가하도록 로직 추가
- 채팅방 시작 API, 채팅방 입장 API: 차단 당한 회원과의 채팅방에 입장 시, 차단당한 상태임을 알려주는 응답값 추가 
- 채팅 등록 API: 차단한/차단 당한 회원에게 채팅 메시지 전송 불가하도록 로직 추가
- MemberUtils 내 공용 메소드 이름 오타 수정: isBocked -> isBlocked

## ⏳ 작업 내용
- [x] 회원 차단 API에 채팅방, 친구 관련 로직 추가
- [x] 채팅방 시작 API 응답값 추가 및 차단 관련 검증 로직 추가
- [x] 채팅방 입장 API 응답값 추가 및 차단 관련 검증 로직 추가
- [x] 채팅 등록 API 차단 관련 검증 로직 추가

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
