### PR TITLE
[Feat/128] 친구 관련 API 구현

### DIFF
--- a/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
@@ -119,6 +119,8 @@ public enum ErrorStatus implements BaseErrorCode {
         "내가 차단한 회원입니다. 친구 요청을 보낼 수 없습니다."),
     BLOCKED_BY_FRIEND_TARGET(HttpStatus.BAD_REQUEST, "FRIEND403",
         "나를 차단한 회원입니다. 친구 요청을 보낼 수 없습니다."),
+    PENDING_FRIEND_REQUEST_EXIST(HttpStatus.BAD_REQUEST, "FRIEND404",
+        "해당 회원에게 보낸 수락 대기 중인 친구 요청이 존재합니다. 친구 요청을 보낼 수 없습니다."),
 
     // 알림 관련 에러
     NOTIFICATION_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI401", "잘못된 알림 타입입니다."),

--- a/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
@@ -119,8 +119,12 @@ public enum ErrorStatus implements BaseErrorCode {
         "내가 차단한 회원입니다. 친구 요청을 보낼 수 없습니다."),
     BLOCKED_BY_FRIEND_TARGET(HttpStatus.BAD_REQUEST, "FRIEND403",
         "나를 차단한 회원입니다. 친구 요청을 보낼 수 없습니다."),
-    PENDING_FRIEND_REQUEST_EXIST(HttpStatus.BAD_REQUEST, "FRIEND404",
+    MY_PENDING_FRIEND_REQUEST_EXIST(HttpStatus.BAD_REQUEST, "FRIEND404",
         "해당 회원에게 보낸 수락 대기 중인 친구 요청이 존재합니다. 친구 요청을 보낼 수 없습니다."),
+    TARGET_PENDING_FRIEND_REQUEST_EXIST(HttpStatus.BAD_REQUEST, "FRIEND405",
+        "해당 회원이 나에게 보낸 친구 요청이 수락 대기 중 입니다. 해당 요청을 수락 해주세요."),
+
+    PENDING_FRIEND_REQUEST_NOT_EXIST(HttpStatus.NOT_FOUND, "FRIEND406", "수락/거절할 친구 요청이 존재하지 않습니다."),
 
     // 알림 관련 에러
     NOTIFICATION_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI401", "잘못된 알림 타입입니다."),

--- a/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
@@ -127,6 +127,8 @@ public enum ErrorStatus implements BaseErrorCode {
         "두 회원은 이미 친구 관계 입니다. 친구 요청을 보낼 수 없습니다."),
 
     PENDING_FRIEND_REQUEST_NOT_EXIST(HttpStatus.NOT_FOUND, "FRIEND407", "수락/거절할 친구 요청이 존재하지 않습니다."),
+    MEMBERS_NOT_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND408", "두 회원은 친구 관계가 아닙니다."),
+    ALREADY_STAR_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND409", "이미 즐겨찾기 되어 있는 친구입니다."),
 
     // 알림 관련 에러
     NOTIFICATION_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI401", "잘못된 알림 타입입니다."),

--- a/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
@@ -123,8 +123,10 @@ public enum ErrorStatus implements BaseErrorCode {
         "해당 회원에게 보낸 수락 대기 중인 친구 요청이 존재합니다. 친구 요청을 보낼 수 없습니다."),
     TARGET_PENDING_FRIEND_REQUEST_EXIST(HttpStatus.BAD_REQUEST, "FRIEND405",
         "해당 회원이 나에게 보낸 친구 요청이 수락 대기 중 입니다. 해당 요청을 수락 해주세요."),
+    ALREADY_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND406",
+        "두 회원은 이미 친구 관계 입니다. 친구 요청을 보낼 수 없습니다."),
 
-    PENDING_FRIEND_REQUEST_NOT_EXIST(HttpStatus.NOT_FOUND, "FRIEND406", "수락/거절할 친구 요청이 존재하지 않습니다."),
+    PENDING_FRIEND_REQUEST_NOT_EXIST(HttpStatus.NOT_FOUND, "FRIEND407", "수락/거절할 친구 요청이 존재하지 않습니다."),
 
     // 알림 관련 에러
     NOTIFICATION_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI401", "잘못된 알림 타입입니다."),

--- a/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
@@ -125,10 +125,10 @@ public enum ErrorStatus implements BaseErrorCode {
         "해당 회원이 나에게 보낸 친구 요청이 수락 대기 중 입니다. 해당 요청을 수락 해주세요."),
     ALREADY_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND406",
         "두 회원은 이미 친구 관계 입니다. 친구 요청을 보낼 수 없습니다."),
-
     PENDING_FRIEND_REQUEST_NOT_EXIST(HttpStatus.NOT_FOUND, "FRIEND407", "수락/거절할 친구 요청이 존재하지 않습니다."),
     MEMBERS_NOT_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND408", "두 회원은 친구 관계가 아닙니다."),
     ALREADY_STAR_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND409", "이미 즐겨찾기 되어 있는 친구입니다."),
+    NOT_STAR_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND410", "즐겨찾기 되어 있는 친구가 아닙니다."),
 
     // 알림 관련 에러
     NOTIFICATION_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI401", "잘못된 알림 타입입니다."),

--- a/src/main/java/com/gamegoo/controller/member/FriendController.java
+++ b/src/main/java/com/gamegoo/controller/member/FriendController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,7 +48,7 @@ public class FriendController {
     @Operation(summary = "친구 요청 전송 API", description = "대상 회원에게 친구 요청을 전송하는 API 입니다."
         + "대상 회원에게 친구 요청 알림을 전송하며, 대상 회원이 현재 접속 중인 경우 socket을 통해 실시간 알림을 전송합니다.")
     @Parameter(name = "memberId", description = "친구 요청을 전송할 대상 회원의 id 입니다.")
-    @PostMapping("/send/{memberId}")
+    @PostMapping("/request/{memberId}")
     public ApiResponse<String> sendFriendRequest(
         @PathVariable(name = "memberId") Long targetMemberId) {
         Long memberId = JWTUtil.getCurrentUserId();
@@ -60,7 +61,7 @@ public class FriendController {
 
     @Operation(summary = "친구 요청 수락 API", description = "대상 회원이 보낸 친구 요청을 수락 처리하는 API 입니다.")
     @Parameter(name = "memberId", description = "친구 요청을 수락할 대상 회원의 id 입니다.")
-    @GetMapping("/request/{memberId}/accept")
+    @PatchMapping("/request/{memberId}/accept")
     public ApiResponse<String> acceptFriendRequest(
         @PathVariable(name = "memberId") Long targetMemberId
     ) {
@@ -73,7 +74,7 @@ public class FriendController {
 
     @Operation(summary = "친구 요청 거절 API", description = "대상 회원이 보낸 친구 요청을 거절 처리하는 API 입니다.")
     @Parameter(name = "memberId", description = "친구 요청을 거절할 대상 회원의 id 입니다.")
-    @GetMapping("/request/{memberId}/reject")
+    @PatchMapping("/request/{memberId}/reject")
     public ApiResponse<String> rejectFriendRequest(
         @PathVariable(name = "memberId") Long targetMemberId
     ) {
@@ -86,7 +87,7 @@ public class FriendController {
 
     @Operation(summary = "친구 즐겨찾기 설정 API", description = "대상 친구 회원을 즐겨찾기 설정하는 API 입니다.")
     @Parameter(name = "memberId", description = "즐겨찾기 설정할 친구 회원의 id 입니다.")
-    @GetMapping("/{memberId}/star")
+    @PatchMapping("/{memberId}/star")
     public ApiResponse<MemberResponse.starFriendResultDTO> starFriend(
         @PathVariable(name = "memberId") Long friendMemberId
     ) {

--- a/src/main/java/com/gamegoo/controller/member/FriendController.java
+++ b/src/main/java/com/gamegoo/controller/member/FriendController.java
@@ -119,4 +119,16 @@ public class FriendController {
 
         return ApiResponse.onSuccess(result);
     }
+
+    @Operation(summary = "친구 삭제 API", description = "친구 회원과의 친구 관계를 끊는 API 입니다.")
+    @Parameter(name = "memberId", description = "삭제 처리할 친구 회원의 id 입니다.")
+    @DeleteMapping("/{memberId}")
+    public ApiResponse<String> deleteFriend(
+        @PathVariable(name = "memberId") Long friendMemberId
+    ) {
+        Long memberId = JWTUtil.getCurrentUserId();
+
+        friendService.deleteFriend(memberId, friendMemberId);
+        return ApiResponse.onSuccess("친구 삭제 성공");
+    }
 }

--- a/src/main/java/com/gamegoo/controller/member/FriendController.java
+++ b/src/main/java/com/gamegoo/controller/member/FriendController.java
@@ -4,6 +4,7 @@ import com.gamegoo.apiPayload.ApiResponse;
 import com.gamegoo.converter.MemberConverter;
 import com.gamegoo.domain.friend.Friend;
 import com.gamegoo.dto.member.MemberResponse;
+import com.gamegoo.dto.member.MemberResponse.starFriendResultDTO;
 import com.gamegoo.service.member.FriendService;
 import com.gamegoo.util.JWTUtil;
 import io.swagger.v3.oas.annotations.Operation;
@@ -82,5 +83,21 @@ public class FriendController {
         return ApiResponse.onSuccess("친구 요청 거절 성공");
     }
 
+    @Operation(summary = "친구 즐겨찾기 설정 API", description = "대상 친구 회원을 즐겨찾기 설정하는 API 입니다.")
+    @Parameter(name = "memberId", description = "친구 회원의 id 입니다.")
+    @GetMapping("/{memberId}/star")
+    public ApiResponse<MemberResponse.starFriendResultDTO> starFriend(
+        @PathVariable(name = "memberId") Long friendMemberId
+    ) {
+        Long memberId = JWTUtil.getCurrentUserId();
 
+        Friend friend = friendService.starFriend(memberId, friendMemberId);
+
+        starFriendResultDTO result = starFriendResultDTO.builder()
+            .friendMemberId(friend.getToMember().getId())
+            .result("친구 즐겨찾기 성공")
+            .build();
+
+        return ApiResponse.onSuccess(result);
+    }
 }

--- a/src/main/java/com/gamegoo/controller/member/FriendController.java
+++ b/src/main/java/com/gamegoo/controller/member/FriendController.java
@@ -4,6 +4,7 @@ import com.gamegoo.apiPayload.ApiResponse;
 import com.gamegoo.converter.MemberConverter;
 import com.gamegoo.domain.friend.Friend;
 import com.gamegoo.dto.member.MemberResponse;
+import com.gamegoo.dto.member.MemberResponse.friendRequestResultDTO;
 import com.gamegoo.dto.member.MemberResponse.starFriendResultDTO;
 import com.gamegoo.service.member.FriendService;
 import com.gamegoo.util.JWTUtil;
@@ -49,40 +50,55 @@ public class FriendController {
         + "대상 회원에게 친구 요청 알림을 전송하며, 대상 회원이 현재 접속 중인 경우 socket을 통해 실시간 알림을 전송합니다.")
     @Parameter(name = "memberId", description = "친구 요청을 전송할 대상 회원의 id 입니다.")
     @PostMapping("/request/{memberId}")
-    public ApiResponse<String> sendFriendRequest(
+    public ApiResponse<MemberResponse.friendRequestResultDTO> sendFriendRequest(
         @PathVariable(name = "memberId") Long targetMemberId) {
         Long memberId = JWTUtil.getCurrentUserId();
 
         friendService.sendFriendRequest(memberId, targetMemberId);
 
-        return ApiResponse.onSuccess("친구 요청 전송 성공");
+        MemberResponse.friendRequestResultDTO result = friendRequestResultDTO.builder()
+            .targetMemberId(targetMemberId)
+            .result("친구 요청 전송 성공")
+            .build();
+
+        return ApiResponse.onSuccess(result);
 
     }
 
     @Operation(summary = "친구 요청 수락 API", description = "대상 회원이 보낸 친구 요청을 수락 처리하는 API 입니다.")
     @Parameter(name = "memberId", description = "친구 요청을 수락할 대상 회원의 id 입니다.")
     @PatchMapping("/request/{memberId}/accept")
-    public ApiResponse<String> acceptFriendRequest(
+    public ApiResponse<MemberResponse.friendRequestResultDTO> acceptFriendRequest(
         @PathVariable(name = "memberId") Long targetMemberId
     ) {
         Long memberId = JWTUtil.getCurrentUserId();
 
         friendService.acceptFriendRequest(memberId, targetMemberId);
 
-        return ApiResponse.onSuccess("친구 요청 수락 성공");
+        MemberResponse.friendRequestResultDTO result = friendRequestResultDTO.builder()
+            .targetMemberId(targetMemberId)
+            .result("친구 요청 수락 성공")
+            .build();
+
+        return ApiResponse.onSuccess(result);
     }
 
     @Operation(summary = "친구 요청 거절 API", description = "대상 회원이 보낸 친구 요청을 거절 처리하는 API 입니다.")
     @Parameter(name = "memberId", description = "친구 요청을 거절할 대상 회원의 id 입니다.")
     @PatchMapping("/request/{memberId}/reject")
-    public ApiResponse<String> rejectFriendRequest(
+    public ApiResponse<MemberResponse.friendRequestResultDTO> rejectFriendRequest(
         @PathVariable(name = "memberId") Long targetMemberId
     ) {
         Long memberId = JWTUtil.getCurrentUserId();
 
         friendService.rejectFriendRequest(memberId, targetMemberId);
 
-        return ApiResponse.onSuccess("친구 요청 거절 성공");
+        MemberResponse.friendRequestResultDTO result = friendRequestResultDTO.builder()
+            .targetMemberId(targetMemberId)
+            .result("친구 요청 거절 성공")
+            .build();
+
+        return ApiResponse.onSuccess(result);
     }
 
     @Operation(summary = "친구 즐겨찾기 설정 API", description = "대상 친구 회원을 즐겨찾기 설정하는 API 입니다.")

--- a/src/main/java/com/gamegoo/controller/member/FriendController.java
+++ b/src/main/java/com/gamegoo/controller/member/FriendController.java
@@ -3,7 +3,6 @@ package com.gamegoo.controller.member;
 import com.gamegoo.apiPayload.ApiResponse;
 import com.gamegoo.converter.MemberConverter;
 import com.gamegoo.domain.friend.Friend;
-import com.gamegoo.domain.friend.FriendRequests;
 import com.gamegoo.dto.member.MemberResponse;
 import com.gamegoo.service.member.FriendService;
 import com.gamegoo.util.JWTUtil;
@@ -51,7 +50,7 @@ public class FriendController {
         @PathVariable(name = "memberId") Long targetMemberId) {
         Long memberId = JWTUtil.getCurrentUserId();
 
-        FriendRequests friendRequests = friendService.sendFriendRequest(memberId, targetMemberId);
+        friendService.sendFriendRequest(memberId, targetMemberId);
 
         return ApiResponse.onSuccess("친구 요청 전송 성공");
 

--- a/src/main/java/com/gamegoo/controller/member/FriendController.java
+++ b/src/main/java/com/gamegoo/controller/member/FriendController.java
@@ -56,5 +56,18 @@ public class FriendController {
 
     }
 
+    @Operation(summary = "친구 요청 수락 API", description = "대상 회원이 보낸 친구 요청을 수락 처리하는 API 입니다.")
+    @Parameter(name = "memberId", description = "친구 요청을 수락할 대상 회원의 id 입니다.")
+    @GetMapping("/request/{memberId}/accept")
+    public ApiResponse<String> acceptFriendRequest(
+        @PathVariable(name = "memberId") Long targetMemberId
+    ) {
+        Long memberId = JWTUtil.getCurrentUserId();
+
+        friendService.acceptFriendRequest(memberId, targetMemberId);
+
+        return ApiResponse.onSuccess("친구 요청 수락 성공");
+    }
+
 
 }

--- a/src/main/java/com/gamegoo/controller/member/FriendController.java
+++ b/src/main/java/com/gamegoo/controller/member/FriendController.java
@@ -69,5 +69,18 @@ public class FriendController {
         return ApiResponse.onSuccess("친구 요청 수락 성공");
     }
 
+    @Operation(summary = "친구 요청 거절 API", description = "대상 회원이 보낸 친구 요청을 거절 처리하는 API 입니다.")
+    @Parameter(name = "memberId", description = "친구 요청을 거절할 대상 회원의 id 입니다.")
+    @GetMapping("/request/{memberId}/reject")
+    public ApiResponse<String> rejectFriendRequest(
+        @PathVariable(name = "memberId") Long targetMemberId
+    ) {
+        Long memberId = JWTUtil.getCurrentUserId();
+
+        friendService.rejectFriendRequest(memberId, targetMemberId);
+
+        return ApiResponse.onSuccess("친구 요청 거절 성공");
+    }
+
 
 }

--- a/src/main/java/com/gamegoo/controller/member/FriendController.java
+++ b/src/main/java/com/gamegoo/controller/member/FriendController.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -84,7 +85,7 @@ public class FriendController {
     }
 
     @Operation(summary = "친구 즐겨찾기 설정 API", description = "대상 친구 회원을 즐겨찾기 설정하는 API 입니다.")
-    @Parameter(name = "memberId", description = "친구 회원의 id 입니다.")
+    @Parameter(name = "memberId", description = "즐겨찾기 설정할 친구 회원의 id 입니다.")
     @GetMapping("/{memberId}/star")
     public ApiResponse<MemberResponse.starFriendResultDTO> starFriend(
         @PathVariable(name = "memberId") Long friendMemberId
@@ -95,7 +96,25 @@ public class FriendController {
 
         starFriendResultDTO result = starFriendResultDTO.builder()
             .friendMemberId(friend.getToMember().getId())
-            .result("친구 즐겨찾기 성공")
+            .result("친구 즐겨찾기 설정 성공")
+            .build();
+
+        return ApiResponse.onSuccess(result);
+    }
+
+    @Operation(summary = "친구 즐겨찾기 해제 API", description = "대상 친구 회원을 즐겨찾기 해제하는 API 입니다.")
+    @Parameter(name = "memberId", description = "즐겨찾기 해제할 친구 회원의 id 입니다.")
+    @DeleteMapping("/{memberId}/star")
+    public ApiResponse<MemberResponse.starFriendResultDTO> unstarFriend(
+        @PathVariable(name = "memberId") Long friendMemberId
+    ) {
+        Long memberId = JWTUtil.getCurrentUserId();
+
+        Friend friend = friendService.unstarFriend(memberId, friendMemberId);
+
+        starFriendResultDTO result = starFriendResultDTO.builder()
+            .friendMemberId(friend.getToMember().getId())
+            .result("친구 즐겨찾기 해제 성공")
             .build();
 
         return ApiResponse.onSuccess(result);

--- a/src/main/java/com/gamegoo/domain/friend/Friend.java
+++ b/src/main/java/com/gamegoo/domain/friend/Friend.java
@@ -38,4 +38,8 @@ public class Friend extends BaseDateTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "to_member_id", nullable = false)
     private Member toMember;
+
+    public void updateIsLiked(Boolean isLiked) {
+        this.isLiked = isLiked;
+    }
 }

--- a/src/main/java/com/gamegoo/dto/member/MemberResponse.java
+++ b/src/main/java/com/gamegoo/dto/member/MemberResponse.java
@@ -111,6 +111,16 @@ public class MemberResponse {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class friendRequestResultDTO {
+
+        Long targetMemberId;
+        String result;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class starFriendResultDTO {
 
         Long friendMemberId;

--- a/src/main/java/com/gamegoo/dto/member/MemberResponse.java
+++ b/src/main/java/com/gamegoo/dto/member/MemberResponse.java
@@ -107,4 +107,14 @@ public class MemberResponse {
         boolean isLiked;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class starFriendResultDTO {
+
+        Long friendMemberId;
+        String result;
+    }
+
 }

--- a/src/main/java/com/gamegoo/service/member/FriendService.java
+++ b/src/main/java/com/gamegoo/service/member/FriendService.java
@@ -92,7 +92,7 @@ public class FriendService {
             .toMember(targetMember)
             .build();
 
-        FriendRequests savedFriendRequests = friendRequestsRepository.save(friendRequests);
+        friendRequestsRepository.save(friendRequests);
 
         // 친구 요청 알림 생성
         // member -> targetMember
@@ -218,6 +218,40 @@ public class FriendService {
         }
 
         friend.get().updateIsLiked(true);
+
+        return friend.get();
+    }
+
+    /**
+     * 해당 친구 회원을 즐겨찾기 해제
+     *
+     * @param memberId
+     * @param friendMemberId
+     * @return
+     */
+    public Friend unstarFriend(Long memberId, Long friendMemberId) {
+        Member member = profileService.findMember(memberId);
+        Member friendMember = profileService.findMember(friendMemberId);
+
+        // 본인의 id를 입력한 경우
+        if (member.equals(friendMember)) {
+            throw new FriendHandler(ErrorStatus.FRIEND_BAD_REQUEST);
+        }
+
+        Optional<Friend> friend = friendRepository.findByFromMemberAndToMember(member,
+            friendMember);
+
+        // 두 회원이 친구 관계가 맞는지 검증
+        if (friend.isEmpty()) {
+            throw new FriendHandler(ErrorStatus.MEMBERS_NOT_FRIEND);
+        }
+
+        // 해당 회원이 즐겨찾기 되어있는지 검증
+        if (!friend.get().getIsLiked()) {
+            throw new FriendHandler(ErrorStatus.NOT_STAR_FRIEND);
+        }
+
+        friend.get().updateIsLiked(false);
 
         return friend.get();
     }

--- a/src/main/java/com/gamegoo/service/member/FriendService.java
+++ b/src/main/java/com/gamegoo/service/member/FriendService.java
@@ -65,6 +65,13 @@ public class FriendService {
             throw new FriendHandler(ErrorStatus.BLOCKED_BY_FRIEND_TARGET);
         }
 
+        // 이미 PENDING 상태인 친구 요청이 존재하는 경우
+        friendRequestsRepository.findByFromMemberAndToMemberAndStatus(member, targetMember,
+                FriendRequestStatus.PENDING)
+            .ifPresent(friendRequest -> {
+                throw new FriendHandler(ErrorStatus.PENDING_FRIEND_REQUEST_EXIST);
+            });
+
         FriendRequests friendRequests = FriendRequests.builder()
             .status(FriendRequestStatus.PENDING)
             .fromMember(member)

--- a/src/main/java/com/gamegoo/service/member/FriendService.java
+++ b/src/main/java/com/gamegoo/service/member/FriendService.java
@@ -257,6 +257,23 @@ public class FriendService {
     }
 
     /**
+     * 두 회원 간 친구 관계 삭제
+     *
+     * @param memberId
+     * @param friendMemberId
+     */
+    public void deleteFriend(Long memberId, Long friendMemberId) {
+        Member member = profileService.findMember(memberId);
+        Member friendMember = profileService.findMember(friendMemberId);
+
+        if (member.equals(friendMember)) {
+            throw new FriendHandler(ErrorStatus.FRIEND_BAD_REQUEST);
+        }
+        
+        removeFriendshipIfPresent(member, friendMember);
+    }
+
+    /**
      * fromMember와 toMember가 서로 친구 관계이면, 친구 관계 끊기
      *
      * @param fromMember

--- a/src/main/java/com/gamegoo/service/member/FriendService.java
+++ b/src/main/java/com/gamegoo/service/member/FriendService.java
@@ -188,6 +188,41 @@ public class FriendService {
     }
 
     /**
+     * 친구 회원을 즐겨찾기 설정
+     *
+     * @param memberId
+     * @param friendMemberId
+     * @return
+     */
+
+    public Friend starFriend(Long memberId, Long friendMemberId) {
+        Member member = profileService.findMember(memberId);
+        Member friendMember = profileService.findMember(friendMemberId);
+
+        // 본인의 id를 입력한 경우
+        if (member.equals(friendMember)) {
+            throw new FriendHandler(ErrorStatus.FRIEND_BAD_REQUEST);
+        }
+
+        Optional<Friend> friend = friendRepository.findByFromMemberAndToMember(member,
+            friendMember);
+
+        // 두 회원이 친구 관계가 맞는지 검증
+        if (friend.isEmpty()) {
+            throw new FriendHandler(ErrorStatus.MEMBERS_NOT_FRIEND);
+        }
+
+        // 이미 즐겨찾기 되어있는지 검증
+        if (friend.get().getIsLiked()) {
+            throw new FriendHandler(ErrorStatus.ALREADY_STAR_FRIEND);
+        }
+
+        friend.get().updateIsLiked(true);
+
+        return friend.get();
+    }
+
+    /**
      * fromMember와 toMember가 서로 친구 관계이면, 친구 관계 끊기
      *
      * @param fromMember

--- a/src/main/java/com/gamegoo/service/member/FriendService.java
+++ b/src/main/java/com/gamegoo/service/member/FriendService.java
@@ -65,11 +65,18 @@ public class FriendService {
             throw new FriendHandler(ErrorStatus.BLOCKED_BY_FRIEND_TARGET);
         }
 
-        // 이미 PENDING 상태인 친구 요청이 존재하는 경우
+        // member -> targetMember로 보낸 친구 요청 중 PENDING 상태인 친구 요청이 존재하는 경우
         friendRequestsRepository.findByFromMemberAndToMemberAndStatus(member, targetMember,
                 FriendRequestStatus.PENDING)
             .ifPresent(friendRequest -> {
-                throw new FriendHandler(ErrorStatus.PENDING_FRIEND_REQUEST_EXIST);
+                throw new FriendHandler(ErrorStatus.MY_PENDING_FRIEND_REQUEST_EXIST);
+            });
+
+        // targetMember -> member에게 보낸 친구 요청 중 PENDING 상태인 친구 요청이 존재하는 경우
+        friendRequestsRepository.findByFromMemberAndToMemberAndStatus(targetMember, member,
+                FriendRequestStatus.PENDING)
+            .ifPresent(friendRequests -> {
+                throw new FriendHandler(ErrorStatus.TARGET_PENDING_FRIEND_REQUEST_EXIST);
             });
 
         FriendRequests friendRequests = FriendRequests.builder()


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 친구 요청 전송 API 검증 로직 추가
  - 두 회원이 이미 친구 관계인 경우 친구 요청 불가하도록
  - 내가 상대에게 보낸 친구 요청이 이미 존재하는 경우 새로운 친구 요청 등록 불가하도록
  - 상대가 나에게 보낸 친구 요청이 이미 존재하는 경우 새로운 친구 요청 등록 불가하도록
- 친구 요청 전송 API endpoint 변경
- 친구 요청 수락 API 추가
- 친구 요청 거절 API 추가
- 친구 삭제 API 추가
- 친구 즐겨찾기 추가 API 추가
- 친구 즐겨찾기 해제 API 추가

## ⏳ 작업 내용
- [x] 친구 요청 전송 API 검증 로직 수정 및 endpoint 변경
- [x] 친구 요청 수락 API 구현
- [x] 친구 요청 거절 API 구현
- [x] 친구 삭제 API 구현
- [x] 친구 즐겨찾기 추가 API 구현
- [x] 친구 즐겨찾기 해제 API 구현

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
