### PR TITLE
[Feat/138] 회원 API 관련 기능 추가 개발

### DIFF
--- a/src/main/generated/com/gamegoo/domain/matching/QMatchingRecord.java
+++ b/src/main/generated/com/gamegoo/domain/matching/QMatchingRecord.java
@@ -41,7 +41,7 @@ public class QMatchingRecord extends EntityPathBase<MatchingRecord> {
 
     public final BooleanPath mike = createBoolean("mike");
 
-    public final StringPath rank = createString("rank");
+    public final NumberPath<Integer> rank = createNumber("rank", Integer.class);
 
     public final EnumPath<MatchingStatus> status = createEnum("status", MatchingStatus.class);
 

--- a/src/main/generated/com/gamegoo/domain/matching/QMatchingRecord.java
+++ b/src/main/generated/com/gamegoo/domain/matching/QMatchingRecord.java
@@ -1,4 +1,4 @@
-package com.gamegoo.domain;
+package com.gamegoo.domain.matching;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
@@ -16,7 +16,7 @@ import com.querydsl.core.types.dsl.PathInits;
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QMatchingRecord extends EntityPathBase<MatchingRecord> {
 
-    private static final long serialVersionUID = 75682738L;
+    private static final long serialVersionUID = 1978268795L;
 
     private static final PathInits INITS = PathInits.DIRECT2;
 
@@ -35,19 +35,19 @@ public class QMatchingRecord extends EntityPathBase<MatchingRecord> {
 
     public final NumberPath<Integer> mannerLevel = createNumber("mannerLevel", Integer.class);
 
-    public final StringPath matchingType = createString("matchingType");
+    public final EnumPath<MatchingType> matchingType = createEnum("matchingType", MatchingType.class);
 
-    public final com.gamegoo.domain.Member.QMember member;
+    public final com.gamegoo.domain.member.QMember member;
 
     public final BooleanPath mike = createBoolean("mike");
 
     public final StringPath rank = createString("rank");
 
-    public final StringPath status = createString("status");
+    public final EnumPath<MatchingStatus> status = createEnum("status", MatchingStatus.class);
 
     public final NumberPath<Integer> subPosition = createNumber("subPosition", Integer.class);
 
-    public final EnumPath<com.gamegoo.domain.Member.Tier> tier = createEnum("tier", com.gamegoo.domain.Member.Tier.class);
+    public final EnumPath<com.gamegoo.domain.member.Tier> tier = createEnum("tier", com.gamegoo.domain.member.Tier.class);
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
@@ -74,7 +74,7 @@ public class QMatchingRecord extends EntityPathBase<MatchingRecord> {
 
     public QMatchingRecord(Class<? extends MatchingRecord> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.member = inits.isInitialized("member") ? new com.gamegoo.domain.Member.QMember(forProperty("member")) : null;
+        this.member = inits.isInitialized("member") ? new com.gamegoo.domain.member.QMember(forProperty("member")) : null;
     }
 
 }

--- a/src/main/generated/com/gamegoo/domain/member/QMember.java
+++ b/src/main/generated/com/gamegoo/domain/member/QMember.java
@@ -61,7 +61,7 @@ public class QMember extends EntityPathBase<Member> {
 
     public final NumberPath<Integer> profileImage = createNumber("profileImage", Integer.class);
 
-    public final StringPath rank = createString("rank");
+    public final NumberPath<Integer> rank = createNumber("rank", Integer.class);
 
     public final StringPath refreshToken = createString("refreshToken");
 

--- a/src/main/generated/com/gamegoo/domain/member/QMember.java
+++ b/src/main/generated/com/gamegoo/domain/member/QMember.java
@@ -37,6 +37,8 @@ public class QMember extends EntityPathBase<Member> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
+    public final BooleanPath isAgree = createBoolean("isAgree");
+
     public final EnumPath<LoginType> loginType = createEnum("loginType", LoginType.class);
 
     public final NumberPath<Integer> mainPosition = createNumber("mainPosition", Integer.class);

--- a/src/main/java/com/gamegoo/config/SecurityConfig.java
+++ b/src/main/java/com/gamegoo/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
         List<String> excludedPaths = Arrays.asList("/swagger-ui/", "/v3/api-docs",
                 "/v1/member/join", "/v1/member/login", "/v1/member/email", "/v1/member/refresh",
                 "/v1/member/riot", "/v1/posts/list", "/v1/posts/list/{boardId}",
-                "/v1/test/chatroom/create/matched", "/v1/member/password/reset", "/v1/member/profile/{id}");
+                "/v1/test/chatroom/create/matched", "/v1/member/password/reset", "/v1/member/profile/other");
         return new JWTFilter(jwtUtil, excludedPaths, customUserDetailService);
 
     }
@@ -69,7 +69,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((auth) -> auth
                         .antMatchers("/", "/v1/member/join", "/v1/member/login", "/v1/member/email/**",
                                 "/v1/member/refresh", "/v1/member/riot", "/v1/posts/list/**",
-                                "/v1/test/chatroom/create/matched", "/v1/member/password/reset", "/v1/member/profile/{id}").permitAll()
+                                "/v1/test/chatroom/create/matched", "/v1/member/password/reset", "/v1/member/profile/other").permitAll()
                         .antMatchers("/", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(new JWTExceptionHandlerFilter(),

--- a/src/main/java/com/gamegoo/controller/member/ProfileController.java
+++ b/src/main/java/com/gamegoo/controller/member/ProfileController.java
@@ -78,8 +78,8 @@ public class ProfileController {
 
     }
 
-    @Operation(summary = "jwt 토큰이 필요한 회원 조회 API 입니다.", description = "API for looking up member with jwt")
-    @GetMapping("/profile/jwt")
+    @Operation(summary = "내 프로필 조회 API 입니다. (jwt 토큰 O)", description = "API for looking up member with jwt")
+    @GetMapping("/profile")
     public ApiResponse<MemberResponse.myProfileMemberDTO> getMemberJWT() {
         Long memberId = JWTUtil.getCurrentUserId();
 
@@ -88,8 +88,8 @@ public class ProfileController {
         return ApiResponse.onSuccess(MemberConverter.toMyProfileDTO(myProfile));
     }
 
-    @Operation(summary = "회원 조회 API 입니다.", description = "API for looking up member")
-    @GetMapping("/profile")
+    @Operation(summary = "다른 회원 프로필 조회 API 입니다. (jwt 토큰 X)", description = "API for looking up member")
+    @GetMapping("/profile/other")
     public ApiResponse<MemberResponse.myProfileMemberDTO> getMember(@RequestParam("id") Long memberId) {
         Member myProfile = profileService.findMember(memberId);
 

--- a/src/main/java/com/gamegoo/converter/MemberConverter.java
+++ b/src/main/java/com/gamegoo/converter/MemberConverter.java
@@ -67,13 +67,17 @@ public class MemberConverter {
                 .manner(member.getMannerLevel())
                 .mainP(member.getMainPosition())
                 .subP(member.getSubPosition())
+                .isAgree(member.getIsAgree())
+                .isBlind(member.getBlind())
+                .winrate(member.getWinRate())
+                .loginType(String.valueOf(member.getLoginType()))
                 .updatedAt(String.valueOf(member.getUpdatedAt()))
                 .gameStyleResponseDTOList(gameStyleResponseDTOList)
                 .championResponseDTOList(championResponseDTOList)
                 .build();
 
     }
-    
+
     public static MemberResponse.friendInfoDTO toFriendInfoDto(Friend friend) {
         return MemberResponse.friendInfoDTO.builder()
                 .memberId(friend.getToMember().getId())

--- a/src/main/java/com/gamegoo/converter/MemberConverter.java
+++ b/src/main/java/com/gamegoo/converter/MemberConverter.java
@@ -1,13 +1,12 @@
 package com.gamegoo.converter;
 
-import com.gamegoo.domain.member.Member;
 import com.gamegoo.domain.friend.Friend;
+import com.gamegoo.domain.member.Member;
 import com.gamegoo.dto.member.MemberResponse;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.stream.Collectors;
-
-import org.springframework.data.domain.Page;
 
 public class MemberConverter {
 
@@ -65,13 +64,16 @@ public class MemberConverter {
                 .tier(member.getTier())
                 .rank(member.getRank())
                 .profileImg(member.getProfileImage())
+                .manner(member.getMannerLevel())
+                .mainP(member.getMainPosition())
+                .subP(member.getSubPosition())
                 .updatedAt(String.valueOf(member.getUpdatedAt()))
                 .gameStyleResponseDTOList(gameStyleResponseDTOList)
                 .championResponseDTOList(championResponseDTOList)
                 .build();
 
     }
-
+    
     public static MemberResponse.friendInfoDTO toFriendInfoDto(Friend friend) {
         return MemberResponse.friendInfoDTO.builder()
                 .memberId(friend.getToMember().getId())

--- a/src/main/java/com/gamegoo/dto/member/MemberResponse.java
+++ b/src/main/java/com/gamegoo/dto/member/MemberResponse.java
@@ -93,6 +93,10 @@ public class MemberResponse {
         String updatedAt;
         Integer mainP;
         Integer subP;
+        Boolean isAgree;
+        Boolean isBlind;
+        String loginType;
+        Double winrate;
         List<GameStyleResponseDTO> gameStyleResponseDTOList;
         List<ChampionResponseDTO> championResponseDTOList;
     }

--- a/src/main/java/com/gamegoo/dto/member/MemberResponse.java
+++ b/src/main/java/com/gamegoo/dto/member/MemberResponse.java
@@ -89,7 +89,10 @@ public class MemberResponse {
         String tag;
         Tier tier;
         String rank;
+        Integer manner;
         String updatedAt;
+        Integer mainP;
+        Integer subP;
         List<GameStyleResponseDTO> gameStyleResponseDTOList;
         List<ChampionResponseDTO> championResponseDTOList;
     }

--- a/src/main/java/com/gamegoo/service/member/AuthService.java
+++ b/src/main/java/com/gamegoo/service/member/AuthService.java
@@ -81,6 +81,7 @@ public class AuthService {
                 .profileImage(randomProfileImage)
                 .blind(false)
                 .mike(false)
+                .mannerLevel(1)
                 .isAgree(isAgree)
                 .build();
 

--- a/src/main/java/com/gamegoo/service/member/AuthService.java
+++ b/src/main/java/com/gamegoo/service/member/AuthService.java
@@ -128,10 +128,10 @@ public class AuthService {
      * @param email
      */
     @Transactional
-    public void sendEmail(String email, Boolean ischeck) {
+    public void sendEmail(String email, Boolean isCheck) {
         // 중복 확인하기
         boolean isPresent = memberRepository.findByEmail(email).isPresent();
-        if (isPresent && ischeck) {
+        if (isPresent && isCheck) {
             throw new MemberHandler(ErrorStatus.MEMBER_CONFLICT);
         }
 

--- a/src/main/java/com/gamegoo/service/member/ProfileService.java
+++ b/src/main/java/com/gamegoo/service/member/ProfileService.java
@@ -2,9 +2,9 @@ package com.gamegoo.service.member;
 
 import com.gamegoo.apiPayload.code.status.ErrorStatus;
 import com.gamegoo.apiPayload.exception.handler.MemberHandler;
-import com.gamegoo.domain.member.Member;
 import com.gamegoo.domain.gamestyle.GameStyle;
 import com.gamegoo.domain.gamestyle.MemberGameStyle;
+import com.gamegoo.domain.member.Member;
 import com.gamegoo.repository.member.GameStyleRepository;
 import com.gamegoo.repository.member.MemberGameStyleRepository;
 import com.gamegoo.repository.member.MemberRepository;
@@ -35,7 +35,13 @@ public class ProfileService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-
+        /*
+        1. 전화 시간 안지킴. 11시에 보는거였는데 20분 30분에 만남. 나는 11시부터 너랑 통화할거 생각해서 일 끝내고 루틴 마무리해서 기다리고있음.
+        2. 원래는 본인이 뭐 하면 뭐한다고 얘기하는데 요즘 그런거 없어짐
+        3. 난 평소에 너 뭐하는지 궁금한데 너는 나만큼 내 삶에 대해서 궁금해주지 않는 것 같음.
+        4. 나를 만나는 날이 아니면 너의 일상에서 나에게 할당된 시간이 짧다고 느껴짐
+        5. 일하는건 이해되는데 배드민턴 칠 때 뭐하느라 그렇게 연락 많이 못보는지 궁금함. 일할 때 자주 연락해주는건 고마움. 근데 도대체 일끝났는데 왜 연락이 그렇게 안되는건지 살짝 설명이 필요함. 3시간동안 배드민턴한다고 연락을 안보는게 이해가 안됨. 중간중간 내 생각이 안나는지 궁금함.
+         */
         // 요청으로 온 gamestyleId로 GameStyle 엔티티 리스트를 생성 및 gamestyleId에 해당하는 gamestyle이 db에 존재하는지 검증
         List<GameStyle> requestGameStyleList = gameStyleIdList.stream()
                 .map(gameStyleId -> gameStyleRepository.findById(gameStyleId)

--- a/src/main/java/com/gamegoo/service/member/ProfileService.java
+++ b/src/main/java/com/gamegoo/service/member/ProfileService.java
@@ -35,13 +35,7 @@ public class ProfileService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-        /*
-        1. 전화 시간 안지킴. 11시에 보는거였는데 20분 30분에 만남. 나는 11시부터 너랑 통화할거 생각해서 일 끝내고 루틴 마무리해서 기다리고있음.
-        2. 원래는 본인이 뭐 하면 뭐한다고 얘기하는데 요즘 그런거 없어짐
-        3. 난 평소에 너 뭐하는지 궁금한데 너는 나만큼 내 삶에 대해서 궁금해주지 않는 것 같음.
-        4. 나를 만나는 날이 아니면 너의 일상에서 나에게 할당된 시간이 짧다고 느껴짐
-        5. 일하는건 이해되는데 배드민턴 칠 때 뭐하느라 그렇게 연락 많이 못보는지 궁금함. 일할 때 자주 연락해주는건 고마움. 근데 도대체 일끝났는데 왜 연락이 그렇게 안되는건지 살짝 설명이 필요함. 3시간동안 배드민턴한다고 연락을 안보는게 이해가 안됨. 중간중간 내 생각이 안나는지 궁금함.
-         */
+
         // 요청으로 온 gamestyleId로 GameStyle 엔티티 리스트를 생성 및 gamestyleId에 해당하는 gamestyle이 db에 존재하는지 검증
         List<GameStyle> requestGameStyleList = gameStyleIdList.stream()
                 .map(gameStyleId -> gameStyleRepository.findById(gameStyleId)


### PR DESCRIPTION
## 🚀 개요
회원 API 관련 기능 추가 개발

## 🔍 변경사항
- 이메일 인증 시 나타나는 html 변경
- Member 엔티티에 개인정보처리 동의 선택 추가
- jwt 토큰 없는 회원 조회 API 개발
- 중복 확인 없는 이메일 인증 API 추가

## ⏳ 작업 내용
- [x] matchingDTO에서 manner 제거
- [x] jwt 토큰 없이 회원 조회하기 API 생성
- [x] 로그인 시 프로필 이미지 정보 response에 추가
- [x] gitignore에 generated 폴더 추가 (Q엔티티 깃 X)
- [x] 개인정보동의 선택 유무 DB에 추가
- [x] 중복확인 없는 이메일 인증 API 추가
- [x] 이메일 인증 html 변경

### 📝 논의사항
