### PR TITLE
[Feat/132] 게시판 관련 추가 구현

### DIFF
--- a/src/main/generated/com/gamegoo/domain/QMember.java
+++ b/src/main/generated/com/gamegoo/domain/QMember.java
@@ -33,6 +33,8 @@ public class QMember extends EntityPathBase<Member> {
 
     public final StringPath email = createString("email");
 
+    public final NumberPath<Integer> gameCount = createNumber("gameCount", Integer.class);
+
     public final StringPath gameName = createString("gameName");
 
     public final NumberPath<Long> id = createNumber("id", Long.class);

--- a/src/main/java/com/gamegoo/controller/board/BoardController.java
+++ b/src/main/java/com/gamegoo/controller/board/BoardController.java
@@ -139,7 +139,8 @@ public class BoardController {
     }
 
     @GetMapping("/member/list/{boardId}")
-    @Operation(summary = "회원용 게시판 글 조회 API")
+    @Operation(summary = "회원용 게시판 글 조회 API", description = "게시판에서 글을 조회하는 API 입니다.")
+    @Parameter(name = "boardId", description = "조회할 게시판 글 id 입니다.")
     public ApiResponse<BoardResponse.boardByIdResponseForMemberDTO> getBoardByIdForMember(@PathVariable Long boardId) {
 
         Long memberId = JWTUtil.getCurrentUserId();

--- a/src/main/java/com/gamegoo/controller/board/BoardController.java
+++ b/src/main/java/com/gamegoo/controller/board/BoardController.java
@@ -129,11 +129,22 @@ public class BoardController {
     }
 
     @GetMapping("/list/{boardId}")
-    @Operation(summary = "게시판 글 조회 API", description = "게시판에서 글을 조회하는 API 입니다.")
+    @Operation(summary = "비회원용 게시판 글 조회 API", description = "게시판에서 글을 조회하는 API 입니다.")
     @Parameter(name = "boardId", description = "조회할 게시판 글 id 입니다.")
     public ApiResponse<BoardResponse.boardByIdResponseDTO> getBoardById(@PathVariable Long boardId) {
 
         BoardResponse.boardByIdResponseDTO result = boardService.getBoardById(boardId);
+
+        return ApiResponse.onSuccess(result);
+    }
+
+    @GetMapping("/member/list/{boardId}")
+    @Operation(summary = "회원용 게시판 글 조회 API")
+    public ApiResponse<BoardResponse.boardByIdResponseForMemberDTO> getBoardByIdForMember(@PathVariable Long boardId) {
+
+        Long memberId = JWTUtil.getCurrentUserId();
+
+        BoardResponse.boardByIdResponseForMemberDTO result = boardService.getBoardByIdForMember(boardId, memberId);
 
         return ApiResponse.onSuccess(result);
     }

--- a/src/main/java/com/gamegoo/domain/Member.java
+++ b/src/main/java/com/gamegoo/domain/Member.java
@@ -75,6 +75,9 @@ public class Member extends BaseDateTimeEntity {
     @Column(name = "mike")
     private Boolean mike = false;
 
+    @Column(name = "game_count")
+    private Integer gameCount;
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Board> boardList = new ArrayList<>();
 
@@ -122,10 +125,11 @@ public class Member extends BaseDateTimeEntity {
         this.memberChampionList = new ArrayList<>();
     }
 
-    public void updateRiotDetails(String tier, String rank, Double winRate) {
+    public void updateRiotDetails(String tier, String rank, Double winRate, Integer gameCount) {
         this.tier = tier;
         this.rank = rank;
         this.winRate = winRate;
+        this.gameCount = gameCount;
     }
 
     public void updateRiotBasic(String gameName, String tag) {

--- a/src/main/java/com/gamegoo/dto/board/BoardResponse.java
+++ b/src/main/java/com/gamegoo/dto/board/BoardResponse.java
@@ -101,6 +101,32 @@ public class BoardResponse {
     @Setter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class boardByIdResponseForMemberDTO {
+        Long boardId;
+        Long memberId;
+        Boolean isBlocked;
+        LocalDateTime createdAt;
+        Integer profileImage;
+        String gameName;
+        String tag;
+        Integer mannerLevel;
+        String tier;
+        Boolean mike;
+        List<Long> championList;
+        Integer gameMode;
+        Integer mainPosition;
+        Integer subPosition;
+        Integer wantPosition;
+        Double winRate;
+        List<Long> gameStyles;
+        String contents;
+    }
+
+    @Getter
+    @Builder
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class myBoardListResponseDTO {
         Long boardId;
         Long memberId;

--- a/src/main/java/com/gamegoo/dto/board/BoardResponse.java
+++ b/src/main/java/com/gamegoo/dto/board/BoardResponse.java
@@ -91,6 +91,7 @@ public class BoardResponse {
         Integer mainPosition;
         Integer subPosition;
         Integer wantPosition;
+        Integer recentGameCount;
         Double winRate;
         List<Long> gameStyles;
         String contents;
@@ -117,6 +118,7 @@ public class BoardResponse {
         Integer mainPosition;
         Integer subPosition;
         Integer wantPosition;
+        Integer recentGameCount;
         Double winRate;
         List<Long> gameStyles;
         String contents;

--- a/src/main/java/com/gamegoo/service/board/BoardService.java
+++ b/src/main/java/com/gamegoo/service/board/BoardService.java
@@ -11,6 +11,7 @@ import com.gamegoo.domain.champion.MemberChampion;
 import com.gamegoo.domain.gamestyle.GameStyle;
 import com.gamegoo.dto.board.BoardRequest;
 import com.gamegoo.dto.board.BoardResponse;
+import com.gamegoo.dto.member.RiotResponse;
 import com.gamegoo.repository.board.BoardGameStyleRepository;
 import com.gamegoo.repository.board.BoardRepository;
 import com.gamegoo.repository.member.GameStyleRepository;
@@ -298,6 +299,7 @@ public class BoardService {
                 .mainPosition(board.getMainPosition())
                 .subPosition(board.getSubPosition())
                 .wantPosition(board.getWantPosition())
+                .recentGameCount(poster.getGameCount())
                 .winRate(poster.getWinRate())
                 .gameStyles(board.getBoardGameStyles().stream().map(BoardGameStyle::getId).collect(Collectors.toList()))
                 .contents(board.getContent())
@@ -331,6 +333,7 @@ public class BoardService {
                 .mainPosition(board.getMainPosition())
                 .subPosition(board.getSubPosition())
                 .wantPosition(board.getWantPosition())
+                .recentGameCount(poster.getGameCount())
                 .winRate(poster.getWinRate())
                 .gameStyles(board.getBoardGameStyles().stream().map(BoardGameStyle::getId).collect(Collectors.toList()))
                 .contents(board.getContent())

--- a/src/main/java/com/gamegoo/service/board/BoardService.java
+++ b/src/main/java/com/gamegoo/service/board/BoardService.java
@@ -15,6 +15,7 @@ import com.gamegoo.repository.board.BoardGameStyleRepository;
 import com.gamegoo.repository.board.BoardRepository;
 import com.gamegoo.repository.member.GameStyleRepository;
 import com.gamegoo.repository.member.MemberRepository;
+import com.gamegoo.util.MemberUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -239,6 +240,7 @@ public class BoardService {
     // 게시판 글 목록 조회
     @Transactional(readOnly = true)
     public List<BoardResponse.boardListResponseDTO> getBoardList(Integer mode, String tier, Integer mainPosition, Boolean mike, int pageIdx){
+
         // pageIdx 값 검증.
         if (pageIdx <= 0) {
             throw new PageHandler(ErrorStatus.PAGE_INVALID);
@@ -273,34 +275,66 @@ public class BoardService {
         }).collect(Collectors.toList());
     }
 
-    // 게시판 글 조회
+    // 비회원 게시판 글 조회
     @Transactional(readOnly = true)
     public BoardResponse.boardByIdResponseDTO getBoardById(Long boardId) {
 
         Board board = boardRepository.findById(boardId).orElseThrow(() -> new BoardHandler(ErrorStatus.BOARD_NOT_FOUND));
 
-        Member member = board.getMember();
+        Member poster = board.getMember();
 
         return BoardResponse.boardByIdResponseDTO.builder()
                 .boardId(board.getId())
-                .memberId(member.getId())
+                .memberId(poster.getId())
                 .createdAt(board.getCreatedAt())
                 .profileImage(board.getBoardProfileImage())
-                .gameName(member.getGameName())
-                .tag(member.getTag())
-                .mannerLevel(member.getMannerLevel())
-                .tier(member.getTier())
-                .championList(member.getMemberChampionList().stream().map(MemberChampion::getId).collect(Collectors.toList()))
+                .gameName(poster.getGameName())
+                .tag(poster.getTag())
+                .mannerLevel(poster.getMannerLevel())
+                .tier(poster.getTier())
+                .championList(poster.getMemberChampionList().stream().map(MemberChampion::getId).collect(Collectors.toList()))
                 .mike(board.getMike())
                 .gameMode(board.getMode())
                 .mainPosition(board.getMainPosition())
                 .subPosition(board.getSubPosition())
                 .wantPosition(board.getWantPosition())
-                .winRate(member.getWinRate())
+                .winRate(poster.getWinRate())
                 .gameStyles(board.getBoardGameStyles().stream().map(BoardGameStyle::getId).collect(Collectors.toList()))
                 .contents(board.getContent())
                 .build();
 
+    }
+
+    // 회원 게시판 글 조회
+    @Transactional(readOnly = true)
+    public BoardResponse.boardByIdResponseForMemberDTO getBoardByIdForMember(Long boardId, Long memberId) {
+
+        Board board = boardRepository.findById(boardId).orElseThrow(() -> new BoardHandler(ErrorStatus.BOARD_NOT_FOUND));
+
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Member poster = board.getMember();
+
+        return BoardResponse.boardByIdResponseForMemberDTO.builder()
+                .boardId(board.getId())
+                .memberId(poster.getId())
+                .isBlocked(MemberUtils.isBlocked(member,poster))
+                .createdAt(board.getCreatedAt())
+                .profileImage(board.getBoardProfileImage())
+                .gameName(poster.getGameName())
+                .tag(poster.getTag())
+                .mannerLevel(poster.getMannerLevel())
+                .tier(poster.getTier())
+                .championList(poster.getMemberChampionList().stream().map(MemberChampion::getId).collect(Collectors.toList()))
+                .mike(board.getMike())
+                .gameMode(board.getMode())
+                .mainPosition(board.getMainPosition())
+                .subPosition(board.getSubPosition())
+                .wantPosition(board.getWantPosition())
+                .winRate(poster.getWinRate())
+                .gameStyles(board.getBoardGameStyles().stream().map(BoardGameStyle::getId).collect(Collectors.toList()))
+                .contents(board.getContent())
+                .build();
     }
 
     // 내가 작성한 게시판 글 목록 조회

--- a/src/main/java/com/gamegoo/util/RiotUtil.java
+++ b/src/main/java/com/gamegoo/util/RiotUtil.java
@@ -158,11 +158,12 @@ public class RiotUtil {
             if ("RANKED_SOLO_5x5".equals(entry.getQueueType())) {
                 int wins = entry.getWins();
                 int losses = entry.getLosses();
+                int gameCount = wins+losses;
                 double winrate = (double) wins / (wins + losses);
                 winrate = Math.round(winrate * 1000) / 10.0;
 
                 // DB에 저장
-                member.updateRiotDetails(entry.getTier(), entry.getRank(), winrate);
+                member.updateRiotDetails(entry.getTier(), entry.getRank(), winrate, gameCount);
                 break;
             }
         }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
게시판 관련 추가 구현 

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 회원용/비회원용 게시판 글 조회 API 분리.
- 회원용 게시판 글 조회 API - 글을 조회하는 유저 입장에서 글 작성자 차단 여부 반환.
- 게시판 글 조회 API - 최신 게임 수 데이터 보내주기.

## ⏳ 작업 내용
- [x] 회원용/비회원용 게시판 글 조회 API 분리 및 구현.
- [x] 회원용 게시판 글 조회 API - 글을 조회하는 유저 입장에서 글 작성자 차단 여부 반환.
- [x] 게시판 글 조회 시 최신 게임 수 데이터 response에 추가.

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
