### PR TITLE
[Feat/153] 채팅 시스템 메시지 기능 구현

### DIFF
--- a/src/main/generated/com/gamegoo/domain/chat/QChat.java
+++ b/src/main/generated/com/gamegoo/domain/chat/QChat.java
@@ -35,6 +35,8 @@ public class QChat extends EntityPathBase<Chat> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
+    public final com.gamegoo.domain.board.QBoard sourceBoard;
+
     public final NumberPath<Long> timestamp = createNumber("timestamp", Long.class);
 
     public final com.gamegoo.domain.member.QMember toMember;
@@ -62,6 +64,7 @@ public class QChat extends EntityPathBase<Chat> {
         super(type, metadata, inits);
         this.chatroom = inits.isInitialized("chatroom") ? new QChatroom(forProperty("chatroom"), inits.get("chatroom")) : null;
         this.fromMember = inits.isInitialized("fromMember") ? new com.gamegoo.domain.member.QMember(forProperty("fromMember")) : null;
+        this.sourceBoard = inits.isInitialized("sourceBoard") ? new com.gamegoo.domain.board.QBoard(forProperty("sourceBoard"), inits.get("sourceBoard")) : null;
         this.toMember = inits.isInitialized("toMember") ? new com.gamegoo.domain.member.QMember(forProperty("toMember")) : null;
     }
 

--- a/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
@@ -94,7 +94,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 매너평가 관련 에러
     MANNER_TARGET_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MANNER401", "매너 평가 대상 회원을 찾을 수 없습니다."),
-    BAD_MANNER_TARGET_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MANNER401", "비매너 평가 대상 회원을 찾을 수 없습니다."),
+    BAD_MANNER_TARGET_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MANNER401",
+        "비매너 평가 대상 회원을 찾을 수 없습니다."),
     MANNER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "MANNER401", "매너평가 작성자만 수정 가능합니다."),
     MANNER_KEYWORD_TYPE_INVALID(HttpStatus.BAD_REQUEST, "MANNER401", "매너 키워드 유형은 1~6만 가능합니다."),
     BAD_MANNER_KEYWORD_TYPE_INVALID(HttpStatus.BAD_REQUEST, "MANNER401",
@@ -118,6 +119,7 @@ public enum ErrorStatus implements BaseErrorCode {
         "채팅 상대 회원을 차단한 상태입니다. 채팅 메시지 전송이 불가능합니다."),
     BLOCKED_BY_CHAT_TARGET_SEND_CHAT_FAILED(HttpStatus.FORBIDDEN, "CHAT408",
         "채팅 상대 회원이 나를 차단했습니다. 채팅 메시지 전송이 불가능합니다."),
+    CHAT_TARGET_MEMBER_ID_INVALID(HttpStatus.BAD_REQUEST, "CHAT409", "채팅방 시작 대상 회원 id 값이 잘못되었습니다."),
 
     // 친구 관련 에러
     FRIEND_BAD_REQUEST(HttpStatus.BAD_REQUEST, "FRIEND401", "잘못된 친구 요청입니다."),

--- a/src/main/java/com/gamegoo/controller/chat/ChatController.java
+++ b/src/main/java/com/gamegoo/controller/chat/ChatController.java
@@ -52,15 +52,31 @@ public class ChatController {
         return ApiResponse.onSuccess(chatQueryService.getChatroomList(memberId));
     }
 
-    @Operation(summary = "채팅방 시작 API", description = "특정 대상 회원과의 채팅방을 시작하는 API 입니다.\n\n" +
-        "대상 회원과의 채팅방이 이미 존재하는 경우, 채팅방 uuid, 상대 회원 정보와 채팅 메시지 내역을 리턴합니다.\n\n" +
-        "대상 회원과의 채팅방이 존재하지 않는 경우, 채팅방을 새로 생성해 해당 채팅방의 uuid, 상대 회원 정보를 리턴합니다.")
-    @PostMapping("/chat/start")
-    public ApiResponse<ChatResponse.ChatroomEnterDTO> startChatroom(
-        @RequestBody @Valid ChatRequest.ChatroomStartRequest request
+    @Operation(summary = "특정 회원과 채팅방 시작 API", description = "특정 대상 회원과의 채팅방을 시작하는 API 입니다.\n\n" +
+        "대상 회원과의 채팅방이 이미 존재하는 경우, 채팅방 uuid, 상대 회원 정보와 채팅 메시지 내역 등을 리턴합니다.\n\n" +
+        "대상 회원과의 채팅방이 존재하지 않는 경우, 채팅방을 새로 생성해 해당 채팅방의 uuid, 상대 회원 정보 등을 리턴합니다.")
+    @Parameter(name = "memberId", description = "채팅방을 시작할 대상 회원의 id 입니다.")
+    @GetMapping("/chat/start/member/{memberId}")
+    public ApiResponse<ChatResponse.ChatroomEnterDTO> startChatroomByMemberId(
+        @PathVariable(name = "memberId") Long targetMemberId
     ) {
         Long memberId = JWTUtil.getCurrentUserId();
-        return ApiResponse.onSuccess(chatCommandService.startChatroom(request, memberId));
+        return ApiResponse.onSuccess(
+            chatCommandService.startChatroomByMemberId(memberId, targetMemberId));
+    }
+
+    @Operation(summary = "특정 글을 보고 채팅방 시작 API", description =
+        "특정 글에서 말 걸어보기 버튼을 통해 채팅방을 시작하는 API 입니다.\n\n" +
+            "대상 회원과의 채팅방이 이미 존재하는 경우, 채팅방 uuid, 상대 회원 정보와 채팅 메시지 내역 등을 리턴합니다.\n\n" +
+            "대상 회원과의 채팅방이 존재하지 않는 경우, 채팅방을 새로 생성해 해당 채팅방의 uuid, 상대 회원 정보 등을 리턴합니다.")
+    @Parameter(name = "boardId", description = "말 걸어보기 버튼을 누른 게시글의 id 입니다.")
+    @GetMapping("/chat/start/board/{boardId}")
+    public ApiResponse<ChatResponse.ChatroomEnterDTO> startChatroomByBoardId(
+        @PathVariable(name = "boardId") Long boardId
+    ) {
+        Long memberId = JWTUtil.getCurrentUserId();
+        return ApiResponse.onSuccess(
+            chatCommandService.startChatroomByBoardId(memberId, boardId));
     }
 
     @Operation(summary = "채팅방 입장 API", description = "특정 채팅방에 입장하는 API 입니다. 채팅 상대의 id, 프로필 이미지, 닉네임 및 해당 채팅방의 안읽은 메시지 및 최근 메시지 목록을 리턴합니다.")

--- a/src/main/java/com/gamegoo/controller/chat/ChatController.java
+++ b/src/main/java/com/gamegoo/controller/chat/ChatController.java
@@ -3,7 +3,6 @@ package com.gamegoo.controller.chat;
 import com.gamegoo.apiPayload.ApiResponse;
 import com.gamegoo.converter.ChatConverter;
 import com.gamegoo.domain.chat.Chat;
-import com.gamegoo.domain.chat.Chatroom;
 import com.gamegoo.dto.chat.ChatRequest;
 import com.gamegoo.dto.chat.ChatResponse;
 import com.gamegoo.service.chat.ChatCommandService;
@@ -11,6 +10,7 @@ import com.gamegoo.service.chat.ChatQueryService;
 import com.gamegoo.util.JWTUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import javax.validation.Valid;
@@ -141,25 +141,23 @@ public class ChatController {
         return ApiResponse.onSuccess("채팅방 나가기 성공");
     }
 
-    @Operation(summary = "채팅방 생성 API (서버 테스트용)", description = "채팅방을 생성하는 API 입니다. 서버 테스트용!!")
-    @PostMapping("/test/chatroom/create")
-    public ApiResponse<ChatResponse.ChatroomCreateResultDTO> createChatroom(
-        @RequestBody @Valid ChatRequest.ChatroomCreateRequest request
+    @Operation(summary = "매칭을 통한 채팅방 시작 메소드 테스트용 API", description =
+        "매칭을 통한 채팅방 시작 메소드를 테스트하기 위한 API 입니다.\n\n" +
+            "대상 회원과의 채팅방이 이미 존재하는 경우, 해당 채팅방 uuid를 리턴합니다.\n\n" +
+            "대상 회원과의 채팅방이 존재하지 않는 경우, 채팅방을 새로 생성해 해당 채팅방의 uuid를 리턴합니다.")
+    @Parameters({
+        @Parameter(name = "memberId1", description = "매칭 시켜줄 회원 id 입니다."),
+        @Parameter(name = "memberId2", description = "매칭 시켜줄 회원 id 입니다.")
+    })
+
+    @GetMapping("/chat/start/matching/{memberId1}/{memberId2}")
+    public ApiResponse<String> startChatroomByMatching(
+        @PathVariable(name = "memberId1") Long memberId1,
+        @PathVariable(name = "memberId2") Long memberId2
     ) {
         Long memberId = JWTUtil.getCurrentUserId();
-        Chatroom chatroom = chatCommandService.createChatroom(request, memberId);
         return ApiResponse.onSuccess(
-            ChatConverter.toChatroomCreateResultDTO(chatroom, request.getTargetMemberId()));
+            chatCommandService.startChatroomByMatching(memberId1, memberId2));
     }
 
-    @Operation(summary = "채팅방 생성 by Matching API (서버 테스트용)", description = "매칭을 통한 채팅방을 생성하는 API 입니다. 서버 테스트용!!")
-    @PostMapping("/test/chatroom/create/matched")
-    public ApiResponse<ChatResponse.ChatroomCreateResultDTO> createChatroomByMatching(
-        @RequestBody @Valid ChatRequest.ChatroomCreateByMatchRequest request
-    ) {
-        Chatroom chatroomByMatch = chatCommandService.createChatroomByMatch(request);
-        return ApiResponse.onSuccess(
-            ChatConverter.toChatroomCreateResultDTO(chatroomByMatch, null));
-
-    }
 }

--- a/src/main/java/com/gamegoo/controller/chat/ChatController.java
+++ b/src/main/java/com/gamegoo/controller/chat/ChatController.java
@@ -93,7 +93,7 @@ public class ChatController {
     @PostMapping("/chat/{chatroomUuid}")
     public ApiResponse<ChatResponse.ChatCreateResultDTO> addChat(
         @PathVariable(name = "chatroomUuid") String chatroomUuid,
-        @RequestBody ChatRequest.ChatCreateRequest request
+        @RequestBody @Valid ChatRequest.ChatCreateRequest request
     ) {
         Long memberId = JWTUtil.getCurrentUserId();
         Chat chat = chatCommandService.addChat(request, chatroomUuid, memberId);

--- a/src/main/java/com/gamegoo/converter/ChatConverter.java
+++ b/src/main/java/com/gamegoo/converter/ChatConverter.java
@@ -34,7 +34,13 @@ public class ChatConverter {
 
     public static ChatResponse.ChatMessageListDTO toChatMessageListDTO(Slice<Chat> chat) {
         List<ChatResponse.ChatMessageDTO> chatMessageDtoList = chat.stream()
-            .map(ChatConverter::toChatMessageDto).collect(Collectors.toList());
+            .map(chatElement -> {
+                    if (chatElement.getFromMember().getId().equals(0L)) { // 해당 메시지가 시스템 메시지인 경우
+                        return ChatConverter.toSystemMessageDTO(chatElement);
+                    }
+                    return ChatConverter.toChatMessageDto(chatElement);
+                }
+            ).collect(Collectors.toList());
 
         return ChatResponse.ChatMessageListDTO.builder()
             .chatMessageDtoList(chatMessageDtoList)
@@ -56,6 +62,18 @@ public class ChatConverter {
             .timestamp(chat.getTimestamp())
             .build();
 
+    }
+
+    public static ChatResponse.SystemMessageDTO toSystemMessageDTO(Chat chat) {
+        return ChatResponse.SystemMessageDTO.builder()
+            .senderId(chat.getFromMember().getId())
+            .senderName(chat.getFromMember().getGameName())
+            .senderProfileImg(chat.getFromMember().getProfileImage())
+            .message(chat.getContents())
+            .createdAt(DatetimeUtil.toKSTString(chat.getCreatedAt()))
+            .timestamp(chat.getTimestamp())
+            .boardId(chat.getSourceBoard() != null ? chat.getSourceBoard().getId() : null)
+            .build();
     }
 
 }

--- a/src/main/java/com/gamegoo/converter/ChatConverter.java
+++ b/src/main/java/com/gamegoo/converter/ChatConverter.java
@@ -1,7 +1,6 @@
 package com.gamegoo.converter;
 
 import com.gamegoo.domain.chat.Chat;
-import com.gamegoo.domain.chat.Chatroom;
 import com.gamegoo.dto.chat.ChatResponse;
 import com.gamegoo.util.DatetimeUtil;
 import java.util.List;
@@ -9,16 +8,6 @@ import java.util.stream.Collectors;
 import org.springframework.data.domain.Slice;
 
 public class ChatConverter {
-
-    public static ChatResponse.ChatroomCreateResultDTO toChatroomCreateResultDTO(Chatroom chatroom,
-        Long targetMemberId) {
-
-        return ChatResponse.ChatroomCreateResultDTO.builder()
-            .chatroomId(chatroom.getId())
-            .uuid(chatroom.getUuid())
-            .targetMemberId(targetMemberId)
-            .build();
-    }
 
     public static ChatResponse.ChatCreateResultDTO toChatCreateResultDTO(Chat chat) {
 

--- a/src/main/java/com/gamegoo/domain/chat/Chat.java
+++ b/src/main/java/com/gamegoo/domain/chat/Chat.java
@@ -1,9 +1,9 @@
 package com.gamegoo.domain.chat;
 
-import com.gamegoo.domain.member.Member;
+import com.gamegoo.domain.board.Board;
 import com.gamegoo.domain.common.BaseDateTimeEntity;
+import com.gamegoo.domain.member.Member;
 import com.gamegoo.util.TimestampUtil;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -13,7 +13,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.PrePersist;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -49,6 +48,10 @@ public class Chat extends BaseDateTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "to_member_id")
     private Member toMember;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "source_board_id")
+    private Board sourceBoard;
 
     // repository에 저장되기 전에 해당 timestamp를 자동으로 설정
     @PrePersist

--- a/src/main/java/com/gamegoo/dto/chat/ChatRequest.java
+++ b/src/main/java/com/gamegoo/dto/chat/ChatRequest.java
@@ -1,6 +1,9 @@
 package com.gamegoo.dto.chat;
 
 import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
@@ -37,6 +40,20 @@ public class ChatRequest {
 
         @NotEmpty
         String message;
+        @Valid
+        SystemFlagRequest systemFlag;
+    }
+
+    @Getter
+    public static class SystemFlagRequest {
+
+        @Min(1)
+        @Max(2)
+        @NotNull
+        Integer flag;
+
+        @NotNull
+        Long postId;
     }
 
 }

--- a/src/main/java/com/gamegoo/dto/chat/ChatRequest.java
+++ b/src/main/java/com/gamegoo/dto/chat/ChatRequest.java
@@ -41,7 +41,7 @@ public class ChatRequest {
         @NotEmpty
         String message;
         @Valid
-        SystemFlagRequest systemFlag;
+        SystemFlagRequest system;
     }
 
     @Getter
@@ -53,7 +53,7 @@ public class ChatRequest {
         Integer flag;
 
         @NotNull
-        Long postId;
+        Long boardId;
     }
 
 }

--- a/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
+++ b/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 public class ChatResponse {
 
@@ -63,7 +64,7 @@ public class ChatResponse {
 
     }
 
-    @Builder
+    @SuperBuilder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
@@ -75,7 +76,7 @@ public class ChatResponse {
         Long next_cursor;
     }
 
-    @Builder
+    @SuperBuilder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
@@ -87,6 +88,15 @@ public class ChatResponse {
         String message;
         String createdAt;
         Long timestamp;
+    }
+
+    @SuperBuilder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SystemMessageDTO extends ChatMessageDTO {
+
+        Long boardId;
     }
 
     @Builder

--- a/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
+++ b/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
@@ -14,18 +14,6 @@ public class ChatResponse {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ChatroomCreateResultDTO {
-
-        Long chatroomId;
-        String uuid;
-        String postUrl;
-        Long targetMemberId;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
     public static class ChatroomViewDTO {
 
         Long chatroomId;

--- a/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
+++ b/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
@@ -47,6 +47,7 @@ public class ChatResponse {
         "memberProfileImg",
         "friend",
         "blocked",
+        "system",
         "chatMessageList"
     })
     public static class ChatroomEnterDTO {
@@ -57,6 +58,7 @@ public class ChatResponse {
         Integer memberProfileImg;
         boolean friend;
         boolean blocked;
+        SystemFlagDTO system;
         ChatMessageListDTO chatMessageList;
 
     }
@@ -99,5 +101,15 @@ public class ChatResponse {
         String message;
         String createdAt;
         Long timestamp;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SystemFlagDTO {
+
+        Integer flag;
+        Long boardId;
     }
 }

--- a/src/main/java/com/gamegoo/repository/chat/ChatRepositoryCustom.java
+++ b/src/main/java/com/gamegoo/repository/chat/ChatRepositoryCustom.java
@@ -6,12 +6,12 @@ import org.springframework.data.domain.Slice;
 
 public interface ChatRepositoryCustom {
 
-    Integer countUnreadChats(Long chatroomId, Long memberChatroomId);
+    Integer countUnreadChats(Long chatroomId, Long memberChatroomId, Long memberId);
 
-    Slice<Chat> findRecentChats(Long chatroomId, Long memberChatroomId);
+    Slice<Chat> findRecentChats(Long chatroomId, Long memberChatroomId, Long memberId);
 
     Slice<Chat> findChatsByCursor(Long cursor, Long chatroomId, Long memberChatroomId,
-        Pageable pageable);
+        Long memberId, Pageable pageable);
 
 
 }

--- a/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
@@ -522,7 +522,7 @@ public class ChatCommandService {
             Chat targetMemberSystemChat = chatRepository.save(systemChatToTargetMember);
             chatRepository.flush();
 
-            updateLastViewDateBySystemChat(memberChatroom, memberSystemChat.getCreatedAt(),
+            updateLastJoinDateBySystemChat(memberChatroom, memberSystemChat.getCreatedAt(),
                 targetMemberSystemChat.getCreatedAt());
 
         }
@@ -538,6 +538,8 @@ public class ChatCommandService {
         Chat savedChat = chatRepository.save(chat);
         if (request.getSystem() == null) {
             updateLastViewDateByAddChat(memberChatroom, savedChat.getCreatedAt());
+        } else {
+            updateOnlyLastViewDate(memberChatroom, savedChat.getCreatedAt());
         }
 
         return savedChat;
@@ -637,29 +639,23 @@ public class ChatCommandService {
     }
 
     /**
-     * 시스템 메시지 등록 시 나와 상대방의 lastViewDate 업데이트
+     * 시스템 메시지 등록 시 나와 상대방의 lastJoinDate 업데이트
      *
      * @param memberChatroom
      * @param memberSystemChatCreatedAt
      * @param targetSystemChatCreatedAt
      */
-    private void updateLastViewDateBySystemChat(MemberChatroom memberChatroom,
-        LocalDateTime memberSystemChatCreatedAt, LocalDateTime targetSystemChatCreatedAt) {
+    private void updateLastJoinDateBySystemChat(MemberChatroom memberChatroom,
+        LocalDateTime memberSystemChatCreatedAt, LocalDateTime targetSystemChatCreatedAt
+    ) {
         // lastJoinDate가 null인 경우
         if (memberChatroom.getLastJoinDate() == null) {
-            // lastViewDate 업데이트
-            memberChatroom.updateLastViewDate(memberSystemChatCreatedAt);
-
             // lastJoinDate 업데이트
             memberChatroom.updateLastJoinDate(memberSystemChatCreatedAt);
 
             // lastJoinDate 업데이트로 인해 socket room join API 요청
             socketService.joinSocketToChatroom(memberChatroom.getMember().getId(),
                 memberChatroom.getChatroom().getUuid());
-
-        } else {
-            // lastViewDate 업데이트
-            memberChatroom.updateLastViewDate(memberSystemChatCreatedAt);
 
         }
 
@@ -677,6 +673,17 @@ public class ChatCommandService {
             socketService.joinSocketToChatroom(targetMember.getId(),
                 targetMemberChatroom.getChatroom().getUuid());
         }
+    }
+
+    /**
+     * 해당 memberChatroom의 lastViewDate만 업데이트
+     *
+     * @param memberChatroom
+     * @param lastViewDate
+     */
+    private void updateOnlyLastViewDate(MemberChatroom memberChatroom,
+        LocalDateTime lastViewDate) {
+        memberChatroom.updateLastViewDate(lastViewDate);
     }
 
 }

--- a/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
@@ -96,7 +96,7 @@ public class ChatCommandService {
 
             // 최근 메시지 내역 조회
             Slice<Chat> recentChats = chatRepository.findRecentChats(chatroom.get().getId(),
-                memberChatroom.getId());
+                memberChatroom.getId(), member.getId());
 
             // 해당 채팅방의 lastViewDate 업데이트
             memberChatroom.updateLastViewDate(LocalDateTime.now());
@@ -209,7 +209,7 @@ public class ChatCommandService {
 
             // 최근 메시지 내역 조회
             Slice<Chat> recentChats = chatRepository.findRecentChats(chatroom.get().getId(),
-                memberChatroom.getId());
+                memberChatroom.getId(), member.getId());
 
             // 해당 채팅방의 lastViewDate 업데이트
             memberChatroom.updateLastViewDate(LocalDateTime.now());
@@ -437,7 +437,7 @@ public class ChatCommandService {
 
         // 최근 메시지 내역 조회
         Slice<Chat> recentChats = chatRepository.findRecentChats(chatroom.getId(),
-            memberChatroom.getId());
+            memberChatroom.getId(), member.getId());
 
         // 해당 채팅방의 lastViewDate 업데이트
         memberChatroom.updateLastViewDate(LocalDateTime.now());

--- a/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
@@ -219,20 +219,15 @@ public class ChatCommandService {
                 recentChats);
 
             // 시스템 메시지 기능을 위한 SystemFlagDTO 생성
-            ChatResponse.SystemFlagDTO systemFlagDTO = null;
-
-            // 내 lastJoinDate가 null인 경우
-            if (memberChatroom.getLastJoinDate() == null) {
-                systemFlagDTO = ChatResponse.SystemFlagDTO.builder()
-                    .flag(1)
-                    .boardId(boardId)
-                    .build();
-            } else { // 내 lastJoinDate가 null이 아닌 경우
-                systemFlagDTO = ChatResponse.SystemFlagDTO.builder()
+            ChatResponse.SystemFlagDTO systemFlagDTO = memberChatroom.getLastJoinDate() == null
+                ? ChatResponse.SystemFlagDTO.builder()
+                .flag(1)
+                .boardId(boardId)
+                .build()
+                : ChatResponse.SystemFlagDTO.builder()
                     .flag(2)
                     .boardId(boardId)
                     .build();
-            }
 
             return ChatroomEnterDTO.builder()
                 .uuid(chatroom.get().getUuid())
@@ -281,20 +276,15 @@ public class ChatCommandService {
             memberChatroomRepository.save(targetMemberChatroom);
 
             // 시스템 메시지 기능을 위한 SystemFlagDTO 생성
-            ChatResponse.SystemFlagDTO systemFlagDTO = null;
-
-            // 내 lastJoinDate가 null인 경우
-            if (memberChatroom.getLastJoinDate() == null) {
-                systemFlagDTO = ChatResponse.SystemFlagDTO.builder()
-                    .flag(1)
-                    .boardId(boardId)
-                    .build();
-            } else { // 내 lastJoinDate가 null이 아닌 경우
-                systemFlagDTO = ChatResponse.SystemFlagDTO.builder()
+            ChatResponse.SystemFlagDTO systemFlagDTO = memberChatroom.getLastJoinDate() == null
+                ? ChatResponse.SystemFlagDTO.builder()
+                .flag(1)
+                .boardId(boardId)
+                .build()
+                : ChatResponse.SystemFlagDTO.builder()
                     .flag(2)
                     .boardId(boardId)
                     .build();
-            }
 
             return ChatroomEnterDTO.builder()
                 .uuid(savedChatroom.getUuid())
@@ -489,9 +479,9 @@ public class ChatCommandService {
         }
 
         // 등록해야 할 시스템 메시지가 있는 경우
-        if (request.getSystemFlag() != null) {
-            SystemFlagRequest systemFlag = request.getSystemFlag();
-            Optional<Board> board = boardRepository.findById(systemFlag.getPostId());
+        if (request.getSystem() != null) {
+            SystemFlagRequest systemFlag = request.getSystem();
+            Optional<Board> board = boardRepository.findById(systemFlag.getBoardId());
 
             // 시스템 메시지 전송자 member 엔티티 조회
             Member systemMember = profileService.findMember(0L);

--- a/src/main/java/com/gamegoo/service/chat/ChatQueryService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatQueryService.java
@@ -2,21 +2,19 @@ package com.gamegoo.service.chat;
 
 import com.gamegoo.apiPayload.code.status.ErrorStatus;
 import com.gamegoo.apiPayload.exception.handler.ChatHandler;
-import com.gamegoo.domain.member.Member;
 import com.gamegoo.domain.chat.Chat;
 import com.gamegoo.domain.chat.Chatroom;
 import com.gamegoo.domain.chat.MemberChatroom;
+import com.gamegoo.domain.member.Member;
 import com.gamegoo.dto.chat.ChatResponse;
 import com.gamegoo.repository.chat.ChatRepository;
 import com.gamegoo.repository.chat.ChatroomRepository;
 import com.gamegoo.repository.chat.MemberChatroomRepository;
 import com.gamegoo.service.member.ProfileService;
 import com.gamegoo.util.DatetimeUtil;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -56,37 +54,37 @@ public class ChatQueryService {
 
         // 현재 참여중인 memberChatroom을 각 memberChatroom에 속한 chat의 마지막 createdAt 기준 desc 정렬해 조회
         List<MemberChatroom> activeMemberChatroom = memberChatroomRepository.findActiveMemberChatroomOrderByLastChat(
-                member.getId());
+            member.getId());
 
         List<ChatResponse.ChatroomViewDTO> chatroomViewDtoList = activeMemberChatroom.stream()
-                .map(memberChatroom -> {
-                    // 채팅 상대 회원 조회
-                    Member targetMember = memberChatroomRepository.findTargetMemberByChatroomIdAndMemberId(
-                            memberChatroom.getChatroom().getId(), member.getId());
-                    Chatroom chatroom = memberChatroom.getChatroom();
+            .map(memberChatroom -> {
+                // 채팅 상대 회원 조회
+                Member targetMember = memberChatroomRepository.findTargetMemberByChatroomIdAndMemberId(
+                    memberChatroom.getChatroom().getId(), member.getId());
+                Chatroom chatroom = memberChatroom.getChatroom();
 
-                    // 가장 마지막 대화 조회
-                    Optional<Chat> lastChat = chatRepository.findFirstByChatroomIdOrderByCreatedAtDesc(
-                            chatroom.getId());
+                // 가장 마지막 대화 조회
+                Optional<Chat> lastChat = chatRepository.findFirstByChatroomIdOrderByCreatedAtDesc(
+                    chatroom.getId());
 
-                    // 내가 읽지 않은 메시지 개수 조회
-                    Integer unReadCnt = chatRepository.countUnreadChats(
-                            chatroom.getId(), memberChatroom.getId());
+                // 내가 읽지 않은 메시지 개수 조회
+                Integer unReadCnt = chatRepository.countUnreadChats(
+                    chatroom.getId(), memberChatroom.getId(), member.getId());
 
-                    return ChatResponse.ChatroomViewDTO.builder()
-                            .chatroomId(chatroom.getId())
-                            .uuid(chatroom.getUuid())
-                            .targetMemberImg(targetMember.getProfileImage())
-                            .targetMemberName(targetMember.getGameName())
-                            .lastMsg(lastChat.isPresent() ? lastChat.get().getContents() : null)
-                            .lastMsgAt(lastChat.isPresent() ? DatetimeUtil.toKSTString(
-                                    lastChat.get().getCreatedAt())
-                                    : DatetimeUtil.toKSTString(memberChatroom.getLastJoinDate()))
-                            .notReadMsgCnt(unReadCnt)
-                            .build();
+                return ChatResponse.ChatroomViewDTO.builder()
+                    .chatroomId(chatroom.getId())
+                    .uuid(chatroom.getUuid())
+                    .targetMemberImg(targetMember.getProfileImage())
+                    .targetMemberName(targetMember.getGameName())
+                    .lastMsg(lastChat.isPresent() ? lastChat.get().getContents() : null)
+                    .lastMsgAt(lastChat.isPresent() ? DatetimeUtil.toKSTString(
+                        lastChat.get().getCreatedAt())
+                        : DatetimeUtil.toKSTString(memberChatroom.getLastJoinDate()))
+                    .notReadMsgCnt(unReadCnt)
+                    .build();
 
-                })
-                .collect(Collectors.toList());
+            })
+            .collect(Collectors.toList());
 
         return chatroomViewDtoList;
 
@@ -105,11 +103,11 @@ public class ChatQueryService {
 
         // chatroom 엔티티 조회 및 해당 회원의 채팅방이 맞는지 검증
         Chatroom chatroom = chatroomRepository.findByUuid(chatroomUuid)
-                .orElseThrow(() -> new ChatHandler(ErrorStatus.CHATROOM_NOT_EXIST));
+            .orElseThrow(() -> new ChatHandler(ErrorStatus.CHATROOM_NOT_EXIST));
 
         MemberChatroom memberChatroom = memberChatroomRepository.findByMemberIdAndChatroomId(
-                        member.getId(), chatroom.getId())
-                .orElseThrow(() -> new ChatHandler(ErrorStatus.CHATROOM_ACCESS_DENIED));
+                member.getId(), chatroom.getId())
+            .orElseThrow(() -> new ChatHandler(ErrorStatus.CHATROOM_ACCESS_DENIED));
 
         // 해당 회원이 퇴장한 채팅방은 아닌지도 나중에 검증 추가하기
 
@@ -118,9 +116,10 @@ public class ChatQueryService {
         // requestParam으로 cursor가 넘어온 경우
         if (cursor != null) {
             return chatRepository.findChatsByCursor(cursor, chatroom.getId(),
-                    memberChatroom.getId(), pageRequest);
+                memberChatroom.getId(), member.getId(), pageRequest);
         } else { // cursor가 넘어오지 않은 경우 = 해당 chatroom의 가장 최근 chat을 조회하는 요청
-            return chatRepository.findRecentChats(chatroom.getId(), memberChatroom.getId());
+            return chatRepository.findRecentChats(chatroom.getId(), memberChatroom.getId(),
+                member.getId());
         }
     }
 


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 채팅방 시작 API 2개로 분리 및 endpoint 변경, 응답값에 SystemFlagDTO 포함하도록 변경
  - 특정 회원과 채팅방 시작 API
  - 특정 글을 보고 채팅방 시작 API
- 채팅 등록 API request dto에 system 데이터 추가
- 시스템 메시지용 ChatMessage dto 추가
- Chat 엔티티에 Board 엔티티 매핑 추가
- 채팅 내역 관련 쿼리에 내가 받은 시스템 메시지만 필터링 로직 추가
- 특정 글을 보고 채팅 시작 메소드 생성
- 매칭을 통한 채팅방 시작 메소드 구현
- 채팅 등록 메소드에 시스템 메시지 생성 및 저장 로직 추가
- 시스템 메시지 등록 시 나와 상대방의 lastViewDate, lastJoinDate 업데이트 메소드 추가

## ⏳ 작업 내용
- [x] 채팅방 시작 API 로직 추가
  - [x] 특정 글을 보고 요청하는 경우, lastJoinDate 업데이트 여부에 따른 flag 및 boardId 값 응답에 포함
  - [x] memberId로 요청하는 경우, flag 및 boardId null 값으로 설정
  - [x] API endpoint 수정
- [x] 채팅 등록 API 수정
  - [x] request flag 값에 따른 채팅 데이터 등록
- [x] 매칭을 통한 채팅방 시작 메소드 구현
- [x] 매칭을 통한 채팅방 시작 테스트용 API 구현

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
