### PR TITLE
[Refactor/161] 알림 목록 조회, 친구 목록 조회 API 수정

### DIFF
--- a/src/main/java/com/gamegoo/controller/member/FriendController.java
+++ b/src/main/java/com/gamegoo/controller/member/FriendController.java
@@ -32,7 +32,7 @@ public class FriendController {
 
     private final FriendService friendService;
 
-    @Operation(summary = "친구 목록 조회 API", description = "해당 회원의 친구 목록을 조회하는 API 입니다.")
+    @Operation(summary = "친구 목록 조회 API", description = "해당 회원의 친구 목록을 조회하는 API 입니다. 이름 오름차순으로 정렬해 제공합니다.")
     @GetMapping
     public ApiResponse<List<MemberResponse.friendInfoDTO>> getFriendList() {
         Long memberId = JWTUtil.getCurrentUserId();

--- a/src/main/java/com/gamegoo/controller/notification/NotificationController.java
+++ b/src/main/java/com/gamegoo/controller/notification/NotificationController.java
@@ -34,18 +34,16 @@ public class NotificationController {
     @Operation(summary = "알림 목록 조회 API", description = "알림 팝업 화면에서 알림 목록을 조회하는 API 입니다.")
     @Parameters({
         @Parameter(name = "cursor", description = "페이징을 위한 커서, Long 타입 notificationId를 보내주세요. 보내지 않으면 가장 최근 알림 10개를 조회합니다."),
-        @Parameter(name = "type", description = "알림 타입 조회 필터, general 또는 friend를 입력해주세요.")
     })
     @GetMapping
     public ApiResponse<NotificationResponse.cursorNotificationListDTO> getNotificationList(
-        @RequestParam(name = "type") String type,
         @RequestParam(name = "cursor", required = false) Long cursor
     ) {
 
         Long memberId = JWTUtil.getCurrentUserId();
 
         Slice<Notification> notifications = notificationService.getNotificationListByCursor(
-            memberId, type, cursor);
+            memberId, cursor);
 
         return ApiResponse.onSuccess(
             NotificationConverter.toCursorNotificationListDTO(notifications));

--- a/src/main/java/com/gamegoo/repository/notification/NotificationRepositoryCustom.java
+++ b/src/main/java/com/gamegoo/repository/notification/NotificationRepositoryCustom.java
@@ -5,5 +5,5 @@ import org.springframework.data.domain.Slice;
 
 public interface NotificationRepositoryCustom {
 
-    Slice<Notification> findNotificationsByCursorAndType(Long memberId, String type, Long cursor);
+    Slice<Notification> findNotificationsByCursor(Long memberId, Long cursor);
 }

--- a/src/main/java/com/gamegoo/repository/notification/NotificationRepositoryCustomImpl.java
+++ b/src/main/java/com/gamegoo/repository/notification/NotificationRepositoryCustomImpl.java
@@ -21,7 +21,7 @@ public class NotificationRepositoryCustomImpl implements NotificationRepositoryC
     private final JPAQueryFactory queryFactory;
 
     /**
-     * 알림 내역 조회, 커서 기반 페이징 및 type 필터링 포함
+     * 알림 내역 조회, 커서 기반 페이징 포함
      *
      * @param memberId
      * @param type
@@ -29,13 +29,11 @@ public class NotificationRepositoryCustomImpl implements NotificationRepositoryC
      * @return
      */
     @Override
-    public Slice<Notification> findNotificationsByCursorAndType(Long memberId, String type,
-        Long cursor) {
+    public Slice<Notification> findNotificationsByCursor(Long memberId, Long cursor) {
 
         List<Notification> result = queryFactory.selectFrom(notification)
             .where(
                 notification.member.id.eq(memberId),
-                notificationTypeEqualReqeustType(type),
                 idBefore(cursor)
             )
             .orderBy(notification.createdAt.desc())
@@ -47,21 +45,13 @@ public class NotificationRepositoryCustomImpl implements NotificationRepositoryC
             result.remove(CURSOR_PAGE_SIZE);
             hasNext = true;
         }
-        
+
         PageRequest pageRequest = PageRequest.of(0, CURSOR_PAGE_SIZE);
 
         return new SliceImpl<>(result, pageRequest, hasNext);
     }
 
-
     //--- BooleanExpression ---//
-    private BooleanExpression notificationTypeEqualReqeustType(String type) {
-        if (type.equals("general")) {
-            return notification.notificationType.id.in(5, 6, 7, 8);
-        } else {
-            return notification.notificationType.id.in(1, 2, 3, 4);
-        }
-    }
 
     private BooleanExpression idBefore(Long cursor) {
         return cursor != null ? notification.id.lt(cursor) : null;

--- a/src/main/java/com/gamegoo/service/member/BlockService.java
+++ b/src/main/java/com/gamegoo/service/member/BlockService.java
@@ -29,7 +29,7 @@ public class BlockService {
     private final ChatCommandService chatCommandService;
     private final FriendService friendService;
 
-    Integer pageSize = 9;
+    private final static Integer PAGE_SIZE = 10;
 
     /**
      * memberId에 해당하는 회원이 targetMemberId에 해당하는 회원을 차단
@@ -53,15 +53,15 @@ public class BlockService {
 
         // 이미 차단한 회원인지 검증
         boolean isblocked = blockRepository.existsByBlockerMemberAndBlockedMember(member,
-                targetMember);
+            targetMember);
         if (isblocked) {
             throw new BlockHandler(ErrorStatus.ALREADY_BLOCKED);
         }
 
         // block 엔티티 생성 및 연관관계 매핑
         Block block = Block.builder()
-                .blockedMember(targetMember)
-                .build();
+            .blockedMember(targetMember)
+            .build();
         block.setBlockerMember(member);
 
         blockRepository.save(block);
@@ -98,10 +98,10 @@ public class BlockService {
         // member 엔티티 조회
         Member member = profileService.findMember(memberId);
 
-        PageRequest pageRequest = PageRequest.of(pageIdx, pageSize);
+        PageRequest pageRequest = PageRequest.of(pageIdx, PAGE_SIZE);
 
         return memberRepository.findBlockedMembersByBlockerIdAndNotBlind(member.getId(),
-                pageRequest);
+            pageRequest);
     }
 
     /**
@@ -117,7 +117,7 @@ public class BlockService {
 
         // targetMember가 차단 실제로 차단 목록에 존재하는지 검증
         Block block = blockRepository.findByBlockerMemberAndBlockedMember(member, targetMember)
-                .orElseThrow(() -> new BlockHandler(ErrorStatus.TARGET_MEMBER_NOT_BLOCKED));
+            .orElseThrow(() -> new BlockHandler(ErrorStatus.TARGET_MEMBER_NOT_BLOCKED));
 
         block.removeBlockerMember(member); // 양방향 연관관계 제거
         blockRepository.delete(block);

--- a/src/main/java/com/gamegoo/service/member/FriendService.java
+++ b/src/main/java/com/gamegoo/service/member/FriendService.java
@@ -11,6 +11,7 @@ import com.gamegoo.repository.friend.FriendRepository;
 import com.gamegoo.repository.friend.FriendRequestsRepository;
 import com.gamegoo.service.notification.NotificationService;
 import com.gamegoo.util.MemberUtils;
+import com.gamegoo.util.SortUtil;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -35,7 +36,14 @@ public class FriendService {
      */
     @Transactional(readOnly = true)
     public List<Friend> getFriends(Long memberId) {
-        return friendRepository.findAllByFromMemberId(memberId);
+        List<Friend> friendList = friendRepository.findAllByFromMemberId(memberId);
+
+        // 친구 회원의 gameName 기준 오름차순 정렬
+        friendList.sort(
+            (f1, f2) -> SortUtil.memberNameComparator.compare(f1.getToMember().getGameName(),
+                f2.getToMember().getGameName()));
+        
+        return friendList;
     }
 
 

--- a/src/main/java/com/gamegoo/service/notification/NotificationService.java
+++ b/src/main/java/com/gamegoo/service/notification/NotificationService.java
@@ -29,7 +29,7 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final ProfileService profileService;
 
-    private static final int PAGE_SIZE = 5;
+    private static final int PAGE_SIZE = 10;
 
     /**
      * 새로운 알림 생성 및 저장 메소드

--- a/src/main/java/com/gamegoo/service/notification/NotificationService.java
+++ b/src/main/java/com/gamegoo/service/notification/NotificationService.java
@@ -90,15 +90,10 @@ public class NotificationService {
      * @param cursor
      * @return
      */
-    public Slice<Notification> getNotificationListByCursor(Long memberId,
-        String type, Long cursor) {
+    public Slice<Notification> getNotificationListByCursor(Long memberId, Long cursor) {
         Member member = profileService.findMember(memberId);
 
-        if (!"general".equals(type) && !"friend".equals(type)) {
-            throw new NotificationHandler(ErrorStatus.INVALID_NOTIFICATION_TYPE);
-        }
-
-        return notificationRepository.findNotificationsByCursorAndType(member.getId(), type,
+        return notificationRepository.findNotificationsByCursor(member.getId(),
             cursor);
     }
 

--- a/src/main/java/com/gamegoo/util/SortUtil.java
+++ b/src/main/java/com/gamegoo/util/SortUtil.java
@@ -1,0 +1,42 @@
+package com.gamegoo.util;
+
+import java.util.Comparator;
+
+public class SortUtil {
+
+    public static Comparator<String> memberNameComparator = (s1, s2) -> {
+        int length1 = s1.length();
+        int length2 = s2.length();
+        int minLength = Math.min(length1, length2);
+
+        // 각 문자 비교
+        for (int i = 0; i < minLength; i++) {
+            int result = compareChars(s1.charAt(i), s2.charAt(i));
+            if (result != 0) {
+                return result;
+            }
+        }
+
+        // 앞부분이 동일하면, 길이가 짧은 것이 앞으로 오도록 정렬
+        return Integer.compare(length1, length2);
+    };
+
+    // 문자 비교 메서드: 한글 -> 영문자 -> 숫자 순으로 우선순위 지정
+    private static int compareChars(char c1, char c2) {
+        if (Character.isDigit(c1) && Character.isDigit(c2)) {
+            return Character.compare(c1, c2);
+        } else if (Character.isDigit(c1)) {
+            return 1; // 숫자는 항상 뒤로
+        } else if (Character.isDigit(c2)) {
+            return -1; // 숫자는 항상 뒤로
+        } else if (Character.isAlphabetic(c1) && Character.isAlphabetic(c2)) {
+            return Character.compare(c1, c2);
+        } else if (Character.isAlphabetic(c1)) {
+            return 1; // 영문자는 한글보다 뒤
+        } else if (Character.isAlphabetic(c2)) {
+            return -1; // 영문자는 한글보다 뒤
+        } else {
+            return Character.compare(c1, c2); // 기본적으로 유니코드 값 비교
+        }
+    }
+}


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
알림 목록 조회, 친구 목록 조회 API 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
 - 알림 팝업 목록 조회 API의 요청 type 구분 제거
 - 친구 목록 조회 API 응답 회원 이름 오름차순으로 정렬
 - SortUtil 메소드 추가
 - 알림 전체 목록 조회 API, 차단한 회원 목록 조회 API 페이징 개수 수정

## ⏳ 작업 내용
- [x] 알림 팝업 목록 조회 API의 요청 type 구분 제거, 쿼리 메소드 수정
- [x] 친구 목록 조회 API 응답 회원 이름 오름차순으로 정렬
- [x] SortUtil 메소드 추가
- [x] 알림 전체 목록 조회 API, 차단한 회원 목록 조회 API 페이징 개수 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
