### PR TITLE
[Feat/165] 매너평가 등록 시 알림 전송 기능 구현

### DIFF
--- a/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
@@ -105,6 +105,7 @@ public enum ErrorStatus implements BaseErrorCode {
     BAD_MANNER_NOT_FOUND(HttpStatus.NOT_FOUND, "MANNER404", "해당 비매너평가를 찾을 수 없습니다."),
     MANNER_CONFLICT(HttpStatus.CONFLICT, "MANNER409", "매너 평가는 최초 1회만 가능합니다."),
     BAD_MANNER_CONFLICT(HttpStatus.CONFLICT, "MANNER409", "비매너 평가는 최초 1회만 가능합니다."),
+    MANNER_INSERT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "MANNER410", "잘못된 매너평가 등록 요청입니다."),
 
     // 채팅 관련 에러
     CHAT_TARGET_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT401", "채팅 대상 회원을 찾을 수 없습니다."),

--- a/src/main/java/com/gamegoo/domain/notification/NotificationTypeTitle.java
+++ b/src/main/java/com/gamegoo/domain/notification/NotificationTypeTitle.java
@@ -7,7 +7,7 @@ public enum NotificationTypeTitle {
     FRIEND_REQUEST_REJECTED("님이 친구를 거절했어요.", null),
     MANNER_LEVEL_UP("매너레벨이 n단계로 올라갔어요!", "/member/manner"),
     MANNER_LEVEL_DOWN("매너레벨이 n단계로 떨어졌어요.", "/member/manner"),
-    MANNER_KEYWORD_RATED("지난 매칭에서 n 키워드를 받았어요.", "/member/manner"),
+    MANNER_KEYWORD_RATED("지난 매칭에서 n 키워드를 받았어요. 자세한 내용은 내정보에서 확인하세요!", "/member/manner"),
     TEST_ALARM("TEST PUSH. NUMBER: ", null),
     ;
 

--- a/src/main/java/com/gamegoo/service/manner/MannerService.java
+++ b/src/main/java/com/gamegoo/service/manner/MannerService.java
@@ -56,6 +56,11 @@ public class MannerService {
             throw new MemberHandler(ErrorStatus.USER_DEACTIVATED);
         }
 
+        // 본인의 id를 요청한 경우
+        if (member.equals(targetMember)) {
+            throw new MannerHandler(ErrorStatus.MANNER_INSERT_BAD_REQUEST);
+        }
+
         // 매너평가 최초 시도 여부 검증.
         List<MannerRating> mannerRatings = mannerRatingRepository.findByFromMemberIdAndToMemberId(
             member.getId(), targetMember.getId());
@@ -144,6 +149,11 @@ public class MannerService {
         // 비매너평가를 받는 회원 탈퇴 여부 검증.
         if (targetMember.getBlind()) {
             throw new MemberHandler(ErrorStatus.USER_DEACTIVATED);
+        }
+
+        // 본인의 id를 요청한 경우
+        if (member.equals(targetMember)) {
+            throw new MannerHandler(ErrorStatus.MANNER_INSERT_BAD_REQUEST);
         }
 
         // 비매너평가 최초 시도 여부 검증.


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 매너평가 등록 시 알림 전송 기능 구현
- 매너레벨 상승/하락 시 알림 전송 기능 구현
- 매너 평가 등록 시 본인 id를 요청한 경우에 대한 에러 처리 추가

## ⏳ 작업 내용
- [x]  매너평가 등록 시 알림 전송 기능 구현
- [x]  매너레벨 상승/하락 시 알림 전송 기능 구현

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
