### PR TITLE
[Refactor/183] API 응답에 친구 요청 상태 및 차단 여부 추가

### DIFF
--- a/src/main/java/com/gamegoo/config/SecurityConfig.java
+++ b/src/main/java/com/gamegoo/config/SecurityConfig.java
@@ -1,11 +1,15 @@
 package com.gamegoo.config;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
 import com.gamegoo.apiPayload.exception.handler.JWTExceptionHandlerFilter;
 import com.gamegoo.filter.JWTFilter;
 import com.gamegoo.filter.LoginFilter;
 import com.gamegoo.repository.member.MemberRepository;
 import com.gamegoo.security.CustomUserDetailService;
 import com.gamegoo.util.JWTUtil;
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,11 +26,6 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
-import java.util.Arrays;
-import java.util.List;
-
-import static org.springframework.security.config.Customizer.withDefaults;
-
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -39,16 +38,16 @@ public class SecurityConfig {
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
-            throws Exception {
+        throws Exception {
         return configuration.getAuthenticationManager();
     }
 
     @Bean
     public JWTFilter jwtFilter() {
         List<String> excludedPaths = Arrays.asList("/swagger-ui/", "/v3/api-docs",
-                "/v1/member/join", "/v1/member/login", "/v1/member/email", "/v1/member/refresh",
-                "/v1/member/riot", "/v1/posts/list", "/v1/posts/list/{boardId}",
-                "/v1/test/chatroom/create/matched", "/v1/member/password/reset", "/v1/member/profile/other");
+            "/v1/member/join", "/v1/member/login", "/v1/member/email", "/v1/member/refresh",
+            "/v1/member/riot", "/v1/posts/list", "/v1/posts/list/{boardId}",
+            "/v1/test/chatroom/create/matched", "/v1/member/password/reset");
         return new JWTFilter(jwtUtil, excludedPaths, customUserDetailService);
 
     }
@@ -62,24 +61,25 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
 
-                .csrf(AbstractHttpConfigurer::disable)
-                .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .cors(withDefaults())
-                .authorizeHttpRequests((auth) -> auth
-                        .antMatchers("/", "/v1/member/join", "/v1/member/login", "/v1/member/email/**",
-                                "/v1/member/refresh", "/v1/member/riot", "/v1/posts/list/**",
-                                "/v1/test/chatroom/create/matched", "/v1/member/password/reset", "/v1/member/profile/other").permitAll()
-                        .antMatchers("/", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .anyRequest().authenticated())
-                .addFilterBefore(new JWTExceptionHandlerFilter(),
-                        UsernamePasswordAuthenticationFilter.class)
-                .addFilterAt(
-                        new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil,
-                                memberRepository), UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(jwtFilter(), LoginFilter.class)
-                .sessionManagement((session) -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .cors(withDefaults())
+            .authorizeHttpRequests((auth) -> auth
+                .antMatchers("/", "/v1/member/join", "/v1/member/login", "/v1/member/email/**",
+                    "/v1/member/refresh", "/v1/member/riot", "/v1/posts/list/**",
+                    "/v1/test/chatroom/create/matched", "/v1/member/password/reset",
+                    "/v1/member/profile/other").permitAll()
+                .antMatchers("/", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                .anyRequest().authenticated())
+            .addFilterBefore(new JWTExceptionHandlerFilter(),
+                UsernamePasswordAuthenticationFilter.class)
+            .addFilterAt(
+                new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil,
+                    memberRepository), UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(jwtFilter(), LoginFilter.class)
+            .sessionManagement((session) -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return http.build();
     }

--- a/src/main/java/com/gamegoo/controller/member/ProfileController.java
+++ b/src/main/java/com/gamegoo/controller/member/ProfileController.java
@@ -9,13 +9,18 @@ import com.gamegoo.dto.member.MemberResponse;
 import com.gamegoo.service.member.ProfileService;
 import com.gamegoo.util.JWTUtil;
 import io.swagger.v3.oas.annotations.Operation;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.*;
-
-import javax.validation.Valid;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,17 +33,17 @@ public class ProfileController {
     @PutMapping("/gamestyle")
     @Operation(summary = "gamestyle 추가 및 수정 API 입니다.", description = "API for Gamestyle addition and modification ")
     public ApiResponse<List<MemberResponse.GameStyleResponseDTO>> addGameStyle(
-            @RequestBody MemberRequest.GameStyleRequestDTO gameStyleRequestDTO) {
+        @RequestBody MemberRequest.GameStyleRequestDTO gameStyleRequestDTO) {
         Long memberId = JWTUtil.getCurrentUserId();
         List<Long> gameStyleIdList = gameStyleRequestDTO.getGameStyleIdList();
         List<MemberGameStyle> memberGameStyles = profileService.addMemberGameStyles(
-                gameStyleIdList, memberId);
+            gameStyleIdList, memberId);
 
         List<MemberResponse.GameStyleResponseDTO> dtoList = memberGameStyles.stream()
-                .map(memberGameStyle -> MemberResponse.GameStyleResponseDTO.builder()
-                        .gameStyleId(memberGameStyle.getGameStyle().getId())
-                        .gameStyleName(memberGameStyle.getGameStyle().getStyleName())
-                        .build()).collect(Collectors.toList());
+            .map(memberGameStyle -> MemberResponse.GameStyleResponseDTO.builder()
+                .gameStyleId(memberGameStyle.getGameStyle().getId())
+                .gameStyleName(memberGameStyle.getGameStyle().getStyleName())
+                .build()).collect(Collectors.toList());
 
         return ApiResponse.onSuccess(dtoList);
     }
@@ -46,7 +51,7 @@ public class ProfileController {
     @PutMapping("/position")
     @Operation(summary = "주/부 포지션 수정 API 입니다.", description = "API for Main/Sub Position Modification")
     public ApiResponse<String> modifyPosition(
-            @RequestBody @Valid MemberRequest.PositionRequestDTO positionRequestDTO) {
+        @RequestBody @Valid MemberRequest.PositionRequestDTO positionRequestDTO) {
         Long userId = JWTUtil.getCurrentUserId();
         int mainP = positionRequestDTO.getMainP();
         int subP = positionRequestDTO.getSubP();
@@ -59,7 +64,7 @@ public class ProfileController {
     @PutMapping("/profile_image")
     @Operation(summary = "프로필 이미지 수정 API 입니다.", description = "API for Profile Image Modification")
     public ApiResponse<String> modifyPosition(
-            @RequestBody MemberRequest.ProfileImageRequestDTO profileImageDTO) {
+        @RequestBody MemberRequest.ProfileImageRequestDTO profileImageDTO) {
         Long userId = JWTUtil.getCurrentUserId();
         Integer profileImage = profileImageDTO.getProfileImage();
 
@@ -88,12 +93,14 @@ public class ProfileController {
         return ApiResponse.onSuccess(MemberConverter.toMyProfileDTO(myProfile));
     }
 
-    @Operation(summary = "다른 회원 프로필 조회 API 입니다. (jwt 토큰 X)", description = "API for looking up member")
+    @Operation(summary = "다른 회원 프로필 조회 API 입니다. (jwt 토큰 O)", description = "API for looking up member")
     @GetMapping("/profile/other")
-    public ApiResponse<MemberResponse.myProfileMemberDTO> getMember(@RequestParam("id") Long memberId) {
-        Member myProfile = profileService.findMember(memberId);
+    public ApiResponse<MemberResponse.memberProfileDTO> getMember(
+        @RequestParam("id") Long targetMemberId) {
+        Long memberId = JWTUtil.getCurrentUserId();
 
-        return ApiResponse.onSuccess(MemberConverter.toMyProfileDTO(myProfile));
+        return ApiResponse.onSuccess(
+            profileService.getTargetMemberProfile(memberId, targetMemberId));
     }
 
 }

--- a/src/main/java/com/gamegoo/converter/MemberConverter.java
+++ b/src/main/java/com/gamegoo/converter/MemberConverter.java
@@ -3,36 +3,36 @@ package com.gamegoo.converter;
 import com.gamegoo.domain.friend.Friend;
 import com.gamegoo.domain.member.Member;
 import com.gamegoo.dto.member.MemberResponse;
-import org.springframework.data.domain.Page;
-
+import com.gamegoo.util.MemberUtils;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
 
 public class MemberConverter {
 
     public static MemberResponse.blockListDTO toBlockListDTO(Page<Member> blockList) {
         List<MemberResponse.blockedMemberDTO> blockedMemberDtoList = blockList.stream()
-                .map(MemberConverter::toBlockedMemberDTO)
-                .collect(Collectors.toList());
+            .map(MemberConverter::toBlockedMemberDTO)
+            .collect(Collectors.toList());
 
         return MemberResponse.blockListDTO.builder()
-                .blockedMemberDTOList(blockedMemberDtoList)
-                .listSize(blockedMemberDtoList.size())
-                .totalPage(blockList.getTotalPages())
-                .totalElements(blockList.getTotalElements())
-                .isFirst(blockList.isFirst())
-                .isLast(blockList.isLast())
-                .build();
+            .blockedMemberDTOList(blockedMemberDtoList)
+            .listSize(blockedMemberDtoList.size())
+            .totalPage(blockList.getTotalPages())
+            .totalElements(blockList.getTotalElements())
+            .isFirst(blockList.isFirst())
+            .isLast(blockList.isLast())
+            .build();
 
     }
 
     public static MemberResponse.blockedMemberDTO toBlockedMemberDTO(Member member) {
         return MemberResponse.blockedMemberDTO.builder()
-                .memberId(member.getId())
-                .profileImg(member.getProfileImage())
-                .email(member.getEmail())
-                .name(member.getGameName())
-                .build();
+            .memberId(member.getId())
+            .profileImg(member.getProfileImage())
+            .email(member.getEmail())
+            .name(member.getGameName())
+            .build();
 
     }
 
@@ -40,51 +40,97 @@ public class MemberConverter {
         List<MemberResponse.GameStyleResponseDTO> gameStyleResponseDTOList = null;
         if (member.getMemberGameStyleList() != null) {
             gameStyleResponseDTOList = member.getMemberGameStyleList().stream()
-                    .map(memberGameStyle -> MemberResponse.GameStyleResponseDTO.builder()
-                            .gameStyleId(memberGameStyle.getGameStyle().getId())
-                            .gameStyleName(memberGameStyle.getGameStyle().getStyleName())
-                            .build()).collect(Collectors.toList());
+                .map(memberGameStyle -> MemberResponse.GameStyleResponseDTO.builder()
+                    .gameStyleId(memberGameStyle.getGameStyle().getId())
+                    .gameStyleName(memberGameStyle.getGameStyle().getStyleName())
+                    .build()).collect(Collectors.toList());
         }
 
         List<MemberResponse.ChampionResponseDTO> championResponseDTOList = null;
         if (member.getMemberChampionList() != null) {
             championResponseDTOList = member.getMemberChampionList().stream()
-                    .map(memberChampion -> MemberResponse.ChampionResponseDTO.builder()
-                            .championId(memberChampion.getMember().getId())
-                            .championName(memberChampion.getChampion().getName())
-                            .build()).collect(Collectors.toList());
+                .map(memberChampion -> MemberResponse.ChampionResponseDTO.builder()
+                    .championId(memberChampion.getMember().getId())
+                    .championName(memberChampion.getChampion().getName())
+                    .build()).collect(Collectors.toList());
         }
 
         return MemberResponse.myProfileMemberDTO.builder()
-                .id(member.getId())
-                .mike(member.getMike())
-                .email(member.getEmail())
-                .gameName(member.getGameName())
-                .tag(member.getTag())
-                .tier(member.getTier())
-                .rank(member.getRank())
-                .profileImg(member.getProfileImage())
-                .manner(member.getMannerLevel())
-                .mainP(member.getMainPosition())
-                .subP(member.getSubPosition())
-                .isAgree(member.getIsAgree())
-                .isBlind(member.getBlind())
-                .winrate(member.getWinRate())
-                .loginType(String.valueOf(member.getLoginType()))
-                .updatedAt(String.valueOf(member.getUpdatedAt()))
-                .gameStyleResponseDTOList(gameStyleResponseDTOList)
-                .championResponseDTOList(championResponseDTOList)
-                .build();
+            .id(member.getId())
+            .mike(member.getMike())
+            .email(member.getEmail())
+            .gameName(member.getGameName())
+            .tag(member.getTag())
+            .tier(member.getTier())
+            .rank(member.getRank())
+            .profileImg(member.getProfileImage())
+            .manner(member.getMannerLevel())
+            .mainP(member.getMainPosition())
+            .subP(member.getSubPosition())
+            .isAgree(member.getIsAgree())
+            .isBlind(member.getBlind())
+            .winrate(member.getWinRate())
+            .loginType(String.valueOf(member.getLoginType()))
+            .updatedAt(String.valueOf(member.getUpdatedAt()))
+            .gameStyleResponseDTOList(gameStyleResponseDTOList)
+            .championResponseDTOList(championResponseDTOList)
+            .build();
+
+    }
+
+    public static MemberResponse.memberProfileDTO toMemberProfileDTO(Member member,
+        Member targetMember, Boolean isFriend, Long friedRequestMemberId) {
+        List<MemberResponse.GameStyleResponseDTO> gameStyleResponseDTOList = null;
+        if (member.getMemberGameStyleList() != null) {
+            gameStyleResponseDTOList = member.getMemberGameStyleList().stream()
+                .map(memberGameStyle -> MemberResponse.GameStyleResponseDTO.builder()
+                    .gameStyleId(memberGameStyle.getGameStyle().getId())
+                    .gameStyleName(memberGameStyle.getGameStyle().getStyleName())
+                    .build()).collect(Collectors.toList());
+        }
+
+        List<MemberResponse.ChampionResponseDTO> championResponseDTOList = null;
+        if (member.getMemberChampionList() != null) {
+            championResponseDTOList = member.getMemberChampionList().stream()
+                .map(memberChampion -> MemberResponse.ChampionResponseDTO.builder()
+                    .championId(memberChampion.getMember().getId())
+                    .championName(memberChampion.getChampion().getName())
+                    .build()).collect(Collectors.toList());
+        }
+
+        return MemberResponse.memberProfileDTO.builder()
+            .id(member.getId())
+            .mike(member.getMike())
+            .email(member.getEmail())
+            .gameName(member.getGameName())
+            .tag(member.getTag())
+            .tier(member.getTier())
+            .rank(member.getRank())
+            .profileImg(member.getProfileImage())
+            .manner(member.getMannerLevel())
+            .mainP(member.getMainPosition())
+            .subP(member.getSubPosition())
+            .isAgree(member.getIsAgree())
+            .isBlind(member.getBlind())
+            .winrate(member.getWinRate())
+            .loginType(String.valueOf(member.getLoginType()))
+            .updatedAt(String.valueOf(member.getUpdatedAt()))
+            .blocked(MemberUtils.isBlocked(member, targetMember))
+            .friend(isFriend)
+            .friendRequestMemberId(friedRequestMemberId)
+            .gameStyleResponseDTOList(gameStyleResponseDTOList)
+            .championResponseDTOList(championResponseDTOList)
+            .build();
 
     }
 
     public static MemberResponse.friendInfoDTO toFriendInfoDto(Friend friend) {
         return MemberResponse.friendInfoDTO.builder()
-                .memberId(friend.getToMember().getId())
-                .name(friend.getToMember().getGameName())
-                .memberProfileImg(friend.getToMember().getProfileImage())
-                .isLiked(friend.getIsLiked())
-                .build();
+            .memberId(friend.getToMember().getId())
+            .name(friend.getToMember().getGameName())
+            .memberProfileImg(friend.getToMember().getProfileImage())
+            .isLiked(friend.getIsLiked())
+            .build();
     }
 
 }

--- a/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
+++ b/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
@@ -20,6 +20,9 @@ public class ChatResponse {
         String uuid;
         Integer targetMemberImg;
         String targetMemberName;
+        boolean friend;
+        boolean blocked;
+        Long friendRequestMemberId;
         String lastMsg;
         String lastMsgAt;
         Integer notReadMsgCnt;

--- a/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
+++ b/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
@@ -39,6 +39,7 @@ public class ChatResponse {
         "memberProfileImg",
         "friend",
         "blocked",
+        "friendRequestMemberId",
         "system",
         "chatMessageList"
     })

--- a/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
+++ b/src/main/java/com/gamegoo/dto/chat/ChatResponse.java
@@ -47,6 +47,7 @@ public class ChatResponse {
         Integer memberProfileImg;
         boolean friend;
         boolean blocked;
+        Long friendRequestMemberId;
         SystemFlagDTO system;
         ChatMessageListDTO chatMessageList;
 

--- a/src/main/java/com/gamegoo/dto/member/MemberResponse.java
+++ b/src/main/java/com/gamegoo/dto/member/MemberResponse.java
@@ -1,9 +1,12 @@
 package com.gamegoo.dto.member;
 
 import com.gamegoo.domain.member.Tier;
-import lombok.*;
-
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 public class MemberResponse {
 
@@ -97,6 +100,35 @@ public class MemberResponse {
         Boolean isBlind;
         String loginType;
         Double winrate;
+        List<GameStyleResponseDTO> gameStyleResponseDTOList;
+        List<ChampionResponseDTO> championResponseDTOList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class memberProfileDTO {
+
+        Long id;
+        Integer profileImg;
+        Boolean mike;
+        String email;
+        String gameName;
+        String tag;
+        Tier tier;
+        Integer rank;
+        Integer manner;
+        String updatedAt;
+        Integer mainP;
+        Integer subP;
+        Boolean isAgree;
+        Boolean isBlind;
+        String loginType;
+        Double winrate;
+        Boolean blocked; // 해당 회원을 차단했는지 여부
+        Boolean friend; // 해당 회원과의 친구 여부
+        Long friendRequestMemberId; // 해당 회원과의 친구 요청 상태
         List<GameStyleResponseDTO> gameStyleResponseDTOList;
         List<ChampionResponseDTO> championResponseDTOList;
     }

--- a/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
@@ -92,6 +92,8 @@ public class ChatCommandService {
                     .memberProfileImg(targetMember.getProfileImage())
                     .friend(friendService.isFriend(member, targetMember))
                     .blocked(false)
+                    .friendRequestMemberId(
+                        friendService.getFriendRequestMemberId(member, targetMember))
                     .system(null)
                     .chatMessageList(null)
                     .build();
@@ -147,6 +149,8 @@ public class ChatCommandService {
                     .memberProfileImg(targetMember.getProfileImage())
                     .friend(friendService.isFriend(member, targetMember))
                     .blocked(false)
+                    .friendRequestMemberId(
+                        friendService.getFriendRequestMemberId(member, targetMember))
                     .system(systemFlagDTO)
                     .chatMessageList(null)
                     .build();
@@ -558,6 +562,7 @@ public class ChatCommandService {
             .memberProfileImg(targetMember.getProfileImage())
             .friend(friendService.isFriend(member, targetMember))
             .blocked(MemberUtils.isBlocked(targetMember, member))
+            .friendRequestMemberId(friendService.getFriendRequestMemberId(member, targetMember))
             .system(systemFlagDTO)
             .chatMessageList(chatMessageListDTO)
             .build();

--- a/src/main/java/com/gamegoo/service/chat/ChatQueryService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatQueryService.java
@@ -10,8 +10,10 @@ import com.gamegoo.dto.chat.ChatResponse;
 import com.gamegoo.repository.chat.ChatRepository;
 import com.gamegoo.repository.chat.ChatroomRepository;
 import com.gamegoo.repository.chat.MemberChatroomRepository;
+import com.gamegoo.service.member.FriendService;
 import com.gamegoo.service.member.ProfileService;
 import com.gamegoo.util.DatetimeUtil;
+import com.gamegoo.util.MemberUtils;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -31,6 +33,7 @@ public class ChatQueryService {
     private final MemberChatroomRepository memberChatroomRepository;
     private final ChatRepository chatRepository;
     private final ProfileService profileService;
+    private final FriendService friendService;
     private final static int PAGE_SIZE = 20;
 
 
@@ -77,6 +80,10 @@ public class ChatQueryService {
                     .uuid(chatroom.getUuid())
                     .targetMemberImg(targetMember.getProfileImage())
                     .targetMemberName(targetMember.getGameName())
+                    .friend(friendService.isFriend(member, targetMember))
+                    .blocked(MemberUtils.isBlocked(targetMember, member))
+                    .friendRequestMemberId(
+                        friendService.getFriendRequestMemberId(member, targetMember))
                     .lastMsg(lastChat.isPresent() ? lastChat.get().getContents() : null)
                     .lastMsgAt(lastChat.isPresent() ? DatetimeUtil.toKSTString(
                         lastChat.get().getCreatedAt())
@@ -144,7 +151,7 @@ public class ChatQueryService {
             })
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
-        
+
         return unreadChatroomUuids;
     }
 

--- a/src/main/java/com/gamegoo/service/member/ProfileService.java
+++ b/src/main/java/com/gamegoo/service/member/ProfileService.java
@@ -2,25 +2,34 @@ package com.gamegoo.service.member;
 
 import com.gamegoo.apiPayload.code.status.ErrorStatus;
 import com.gamegoo.apiPayload.exception.handler.MemberHandler;
+import com.gamegoo.converter.MemberConverter;
+import com.gamegoo.domain.friend.Friend;
+import com.gamegoo.domain.friend.FriendRequestStatus;
 import com.gamegoo.domain.gamestyle.GameStyle;
 import com.gamegoo.domain.gamestyle.MemberGameStyle;
 import com.gamegoo.domain.member.Member;
+import com.gamegoo.dto.member.MemberResponse;
+import com.gamegoo.repository.friend.FriendRepository;
+import com.gamegoo.repository.friend.FriendRequestsRepository;
 import com.gamegoo.repository.member.GameStyleRepository;
 import com.gamegoo.repository.member.MemberGameStyleRepository;
 import com.gamegoo.repository.member.MemberRepository;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 public class ProfileService {
+
     private final MemberRepository memberRepository;
     private final GameStyleRepository gameStyleRepository;
     private final MemberGameStyleRepository memberGameStyleRepository;
+
+    private final FriendRepository friendRepository;
+    private final FriendRequestsRepository friendRequestsRepository;
 
     /**
      * MemberGameStyle 데이터 추가 : 회원에 따른 게임 스타일 정보 저장하기
@@ -33,14 +42,13 @@ public class ProfileService {
     public List<MemberGameStyle> addMemberGameStyles(List<Long> gameStyleIdList, Long memberId) {
         // 회원 엔티티 조회
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-
+            .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         // 요청으로 온 gamestyleId로 GameStyle 엔티티 리스트를 생성 및 gamestyleId에 해당하는 gamestyle이 db에 존재하는지 검증
         List<GameStyle> requestGameStyleList = gameStyleIdList.stream()
-                .map(gameStyleId -> gameStyleRepository.findById(gameStyleId)
-                        .orElseThrow(() -> new MemberHandler(ErrorStatus.GAMESTYLE_NOT_FOUND)))
-                .toList();
+            .map(gameStyleId -> gameStyleRepository.findById(gameStyleId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.GAMESTYLE_NOT_FOUND)))
+            .toList();
 
         // db에는 존재하나, request에는 존재하지 않는 gameStyle을 삭제
         List<MemberGameStyle> toRemove = new ArrayList<>();
@@ -57,14 +65,14 @@ public class ProfileService {
 
         // request에는 존재하나, db에는 존재하지 않는 gameStyle을 추가
         List<GameStyle> currentGameStyleList = member.getMemberGameStyleList().stream()
-                .map(MemberGameStyle::getGameStyle)
-                .toList();
+            .map(MemberGameStyle::getGameStyle)
+            .toList();
 
         for (GameStyle reqGameStyle : requestGameStyleList) {
             if (!currentGameStyleList.contains(reqGameStyle)) {
                 MemberGameStyle memberGameStyle = MemberGameStyle.builder()
-                        .gameStyle(reqGameStyle)
-                        .build();
+                    .gameStyle(reqGameStyle)
+                    .build();
                 memberGameStyle.setMember(member); // 양방향 연관관계 매핑
                 memberGameStyleRepository.save(memberGameStyle);
             }
@@ -81,7 +89,7 @@ public class ProfileService {
     @Transactional
     public void deleteMember(Long userId) {
         Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+            .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         // Blind 처리
         member.deactiveMember();
@@ -103,7 +111,7 @@ public class ProfileService {
         }
 
         Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+            .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         member.updatePosition(mainP, subP);
         memberRepository.save(member);
@@ -118,7 +126,7 @@ public class ProfileService {
     @Transactional
     public void modifyProfileImage(Long userId, Integer profileImage) {
         Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+            .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         member.updateProfileImage(profileImage);
 
@@ -134,6 +142,36 @@ public class ProfileService {
     @Transactional(readOnly = true)
     public Member findMember(Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+            .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    /**
+     * 특정 회원의 유저프로필 조회, 차단 여부, 친구 여부, 친구 요청 상태 포함
+     *
+     * @param memberId
+     * @param targetMemberId
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public MemberResponse.memberProfileDTO getTargetMemberProfile(Long memberId,
+        Long targetMemberId) {
+        Member member = findMember(memberId);
+        Member targetMember = findMember(targetMemberId);
+
+        List<Friend> friendList = friendRepository.findBothDirections(member, targetMember);
+        boolean isFriend = (friendList.size() == 2);
+
+        Long friendRequestMemberId = friendRequestsRepository.findByFromMemberAndToMemberAndStatus(
+                member, targetMember,
+                FriendRequestStatus.PENDING)
+            .map(friendRequests -> member.getId())
+            .or(() -> friendRequestsRepository.findByFromMemberAndToMemberAndStatus(targetMember,
+                    member, FriendRequestStatus.PENDING)
+                .map(friendRequests -> targetMember.getId()))
+            .orElse(null); // 친구 요청이 없는 경우 null을 리턴
+
+        return MemberConverter.toMemberProfileDTO(member, targetMember,
+            isFriend,
+            friendRequestMemberId);
     }
 }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
API 응답에 친구 요청 상태 및 차단 여부 추가

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- /v1/member/profile/other uri jwtFilter 적용되도록 수정
- 특정 유저 프로필 조회 API 응답 DTO 변경 및 관련 service 코드 추가
- ChatroomEnterDTO에 friendRequestMemberId 추가
- ChatroomViewDTO에 friend, blocked, friendRequestMemberId 추가

## ⏳ 작업 내용
- [x]  회원용 특정 유저 프로필 조회 API 응답값에 isFriend, isBlocked, friendRequestMemberId 추가
- [x]  /v1/chat/{chatroomUuid}/enter 에 friendRequestMemberId 추가
- [x]  /v1/chat/start/member/{memberId} 에 friendRequestMemberId 추가
- [x]  /v1/chat/start/board/{boardId}에 friendRequestMemberId 추가
- [x]  /v1/member/chatroom 에 isFriend, isBlocked, friendRequestMemberId 추가

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
