### PR TITLE
[Fix/194] 매칭 수정사항 변경 및 ErrorStatus 변경

### DIFF
--- a/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
@@ -25,33 +25,34 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // Member 관련 에러
     PASSWORD_INVALID(HttpStatus.BAD_REQUEST, "MEMBER400", "비밀번호가 불일치합니다."),
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "해당 사용자를 찾을 수 없습니다."),
-    USER_DEACTIVATED(HttpStatus.FORBIDDEN, "MEMBER403", "해당 사용자는 탈퇴한 사용자입니다."),
-    MEMBER_CONFLICT(HttpStatus.CONFLICT, "MEMBER409", "이미 있는 사용자입니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER401", "해당 사용자를 찾을 수 없습니다."),
+    USER_DEACTIVATED(HttpStatus.FORBIDDEN, "MEMBER402", "해당 사용자는 탈퇴한 사용자입니다."),
+    MEMBER_CONFLICT(HttpStatus.CONFLICT, "MEMBER403", "이미 있는 사용자입니다."),
 
     // JWT 관련 에러
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "JWT401", "jwt 토큰이 만료되었습니다."),
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "JWT400", "유효하지 않은 jwt 토큰입니다."),
-    TOKEN_NULL(HttpStatus.NOT_FOUND, "JWT404", "JWT 토큰이 없습니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "JWT400", "jwt 토큰이 만료되었습니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "JWT401", "유효하지 않은 jwt 토큰입니다."),
+    TOKEN_NULL(HttpStatus.NOT_FOUND, "JWT402", "JWT 토큰이 없습니다."),
 
     // GameStyle 관련 에러
-    GAMESTYLE_NOT_FOUND(HttpStatus.NOT_FOUND, "GAMESTYLE404", "해당 게임 스타일을 찾을 수 없습니다."),
+    GAMESTYLE_NOT_FOUND(HttpStatus.NOT_FOUND, "GAMESTYLE400", "해당 게임 스타일을 찾을 수 없습니다."),
 
     // Position 관련 에러
-    POSITION_NOT_FOUND(HttpStatus.NOT_FOUND, "POSITION404", "해당 Position을 찾을 수 없습니다."),
+    POSITION_NOT_FOUND(HttpStatus.NOT_FOUND, "POSITION400", "해당 Position을 찾을 수 없습니다."),
 
     // Email 인증 관련 에러
-    EMAIL_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL500", "이메일 전송 도중, 에러가 발생했습니다."),
-    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "EMAIL404", "해당 이메일을 찾을 수 없습니다."),
-    EMAIL_INVALID_CODE(HttpStatus.BAD_REQUEST, "EMAIL400", "인증 코드가 불일치합니다."),
-    EMAIL_INVALID_TIME(HttpStatus.BAD_REQUEST, "EMAIL400", "이메일 인증 시간이 3분 초과했습니다."),
+    EMAIL_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL400", "이메일 전송 도중, 에러가 발생했습니다."),
+    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "EMAIL401", "해당 이메일을 찾을 수 없습니다."),
+    EMAIL_INVALID_CODE(HttpStatus.BAD_REQUEST, "EMAIL402", "인증 코드가 불일치합니다."),
+    EMAIL_INVALID_TIME(HttpStatus.BAD_REQUEST, "EMAIL403", "이메일 인증 시간이 3분 초과했습니다."),
 
     // 매칭 관련 에러
     MATCHING_STATUS_BAD_REQUEST(HttpStatus.BAD_REQUEST, "MATCH400",
             "status는 SUCCESS, FAIL 둘 중 하나로만 변경이 가능합니다."),
-    MATHCING_TYPE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "MATCH400",
+    MATHCING_TYPE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "MATCH401",
             "matchingType은 BASIC, PRECISE 둘 중 하나여야합니다."),
-    MATCHING_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH404", "해당 사용자의 매칭 정보가 없습니다."),
+    MATCHING_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH402", "해당 사용자의 매칭 정보가 없습니다."),
+    MATCHING_FAILED_BY_BLOCK(HttpStatus.BAD_REQUEST, "MATCH403", "차단된 사용자끼리의 매칭은 불가능합니다."),
 
 
     // Riot 관련 에러
@@ -133,9 +134,9 @@ public enum ErrorStatus implements BaseErrorCode {
     TARGET_PENDING_FRIEND_REQUEST_EXIST(HttpStatus.BAD_REQUEST, "FRIEND405",
             "해당 회원이 나에게 보낸 친구 요청이 수락 대기 중 입니다. 해당 요청을 수락 해주세요."),
     ALREADY_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND406",
-        "두 회원은 이미 친구 관계 입니다. 친구 요청을 보낼 수 없습니다."),
+            "두 회원은 이미 친구 관계 입니다. 친구 요청을 보낼 수 없습니다."),
     PENDING_FRIEND_REQUEST_NOT_EXIST(HttpStatus.NOT_FOUND, "FRIEND407",
-        "취소/수락/거절할 친구 요청이 존재하지 않습니다."),
+            "취소/수락/거절할 친구 요청이 존재하지 않습니다."),
     MEMBERS_NOT_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND408", "두 회원은 친구 관계가 아닙니다."),
     ALREADY_STAR_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND409", "이미 즐겨찾기 되어 있는 친구입니다."),
     NOT_STAR_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND410", "즐겨찾기 되어 있는 친구가 아닙니다."),

--- a/src/main/java/com/gamegoo/service/matching/MatchingService.java
+++ b/src/main/java/com/gamegoo/service/matching/MatchingService.java
@@ -140,8 +140,9 @@ public class MatchingService {
         }
 
         // 주/부 포지션 조합이 같을 경우 X
-        if ((otherMainPosition.equals(myMainPosition) && otherSubPosition.equals(mySubPosition)) ||
-                (otherMainPosition.equals(mySubPosition) && otherSubPosition.equals(myMainPosition))) {
+        // 겹치는게 둘 중 하나라도 0일 경우는 X
+        if ((otherMainPosition.equals(myMainPosition) && otherSubPosition.equals(mySubPosition) && !(otherMainPosition.equals(0) || otherSubPosition.equals(0))) ||
+                (otherMainPosition.equals(mySubPosition) && otherSubPosition.equals(myMainPosition) && !(otherMainPosition.equals(0) || otherSubPosition.equals(0)))) {
             return 0;
         }
 

--- a/src/main/java/com/gamegoo/service/matching/MatchingService.java
+++ b/src/main/java/com/gamegoo/service/matching/MatchingService.java
@@ -13,6 +13,7 @@ import com.gamegoo.dto.matching.MatchingResponse;
 import com.gamegoo.dto.matching.MatchingResponse.matchingRequestResponseDTO;
 import com.gamegoo.dto.matching.MemberPriority;
 import com.gamegoo.repository.matching.MatchingRecordRepository;
+import com.gamegoo.repository.member.BlockRepository;
 import com.gamegoo.repository.member.MemberRepository;
 import com.gamegoo.service.member.ProfileService;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,7 @@ public class MatchingService {
 
     private final MemberRepository memberRepository;
     private final MatchingRecordRepository matchingRecordRepository;
+    private final BlockRepository blockRepository;
     private final ProfileService profileService;
 
     /**
@@ -41,14 +43,18 @@ public class MatchingService {
      */
     public MatchingResponse.PriorityMatchingResponseDTO getPriorityLists(
             MatchingRequest.InitializingMatchingRequestDTO request, Long id) throws MemberHandler {
+
+
         // 게임 모드가 같고, 5분동안 매칭이 되지 않은 매칭 기록 가져오기
         LocalDateTime fiveMinutesAgo = LocalDateTime.now().minusMinutes(5);
         List<MatchingRecord> matchingRecords = matchingRecordRepository.findTopByCreatedAtAfterAndStatusAndGameModeGroupByMemberId(
                 fiveMinutesAgo, MatchingStatus.PENDING, request.getGameMode());
+
+        Member member = profileService.findMember(id);
+
         List<MemberPriority> otherPriorityList = new ArrayList<>();
         List<MemberPriority> myPriorityList = new ArrayList<>();
 
-        Member member = profileService.findMember(id);
 
         MatchingRecord myMatchingRecord = MatchingRecord.builder()
                 .member(member)
@@ -68,6 +74,12 @@ public class MatchingService {
         // 우선순위 계산하기
         for (MatchingRecord record : matchingRecords) {
             Long otherMemberId = record.getMember().getId();
+
+            // 서로 차단한 사용자일 경우 우선순위 계산 X
+            if (blockRepository.existsByBlockerMemberAndBlockedMember(member, record.getMember())) {
+                continue;
+            }
+
             if (!id.equals(otherMemberId)) {
                 int otherPriority = calculatePriority(myMatchingRecord, record);
                 myPriorityList.add(new MemberPriority(otherMemberId, otherPriority));

--- a/src/main/java/com/gamegoo/service/matching/MatchingService.java
+++ b/src/main/java/com/gamegoo/service/matching/MatchingService.java
@@ -244,12 +244,12 @@ public class MatchingService {
     }
 
     /**
-     * <매너레벨 가중치> 최대 가중치 16 , 최소 가중치 0 (매너레벨 5, 매너레벨 1 -> (5-1)*4 = 4*4 = 16)
+     * <매너레벨 가중치> 최대 가중치 12 , 최소 가중치 0 (매너레벨 5, 매너레벨 1 -> (5-1)*3 = 4*3 = 12)
      */
     private int getMannerPriority(Integer otherManner, Integer myManner) {
         int priority = 0;
         int mannerDifference = Math.abs(myManner - otherManner);
-        priority += 16 - mannerDifference * 4;
+        priority += 12 - mannerDifference * 3;
         return priority;
     }
 


### PR DESCRIPTION
## 🚀 개요
매칭 수정사항 변경 및 ErrorStatus 변경

## 🔍 변경사항
- ErrorStatus 이효림 작업 부분 중복 없도록 변경
- 포지션 겹칠 때 랜덤일 경우 우선순위 0 안되도록 변경
- 매너레벨 가중치 4->3 변경
- 차단한 회원일 경우 우선순위 리스트에서 제외

## ⏳ 작업 내용
- [x] ErrorStatus 이효림 작업 부분 중복 없도록 변경
- [x] 포지션 겹칠 때 랜덤일 경우 우선순위 0 안되도록 변경
- [x] 매너레벨 가중치 4->3 변경
- [x] 차단한 회원일 경우 우선순위 리스트에서 제외

### 📝 논의사항