### PR TITLE
[Refactor/215] 알림 엔티티 수정 및 탈퇴한 사용자 소환사명 표시 추가

### DIFF
--- a/src/main/generated/com/gamegoo/domain/notification/QNotification.java
+++ b/src/main/generated/com/gamegoo/domain/notification/QNotification.java
@@ -37,7 +37,7 @@ public class QNotification extends EntityPathBase<Notification> {
 
     public final QNotificationType notificationType;
 
-    public final NumberPath<Long> sourceId = createNumber("sourceId", Long.class);
+    public final com.gamegoo.domain.member.QMember sourceMember;
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
@@ -62,6 +62,7 @@ public class QNotification extends EntityPathBase<Notification> {
         super(type, metadata, inits);
         this.member = inits.isInitialized("member") ? new com.gamegoo.domain.member.QMember(forProperty("member")) : null;
         this.notificationType = inits.isInitialized("notificationType") ? new QNotificationType(forProperty("notificationType")) : null;
+        this.sourceMember = inits.isInitialized("sourceMember") ? new com.gamegoo.domain.member.QMember(forProperty("sourceMember")) : null;
     }
 
 }

--- a/src/main/java/com/gamegoo/converter/NotificationConverter.java
+++ b/src/main/java/com/gamegoo/converter/NotificationConverter.java
@@ -48,17 +48,29 @@ public class NotificationConverter {
             StringBuilder urlBuilder = new StringBuilder(
                 notification.getNotificationType().getSourceUrl());
 
-            if (notification.getSourceId() != null) {
-                urlBuilder.append(notification.getSourceId());
+            if (notification.getSourceMember() != null) {
+                urlBuilder.append(notification.getSourceMember().getId());
             }
 
             pageUrl = urlBuilder.toString();
         }
 
+        String content = notification.getContent();
+
+        // sourceMember 닉네임 표시
+        if (notification.getSourceMember() != null) {
+            if (notification.getSourceMember().getBlind()) { // sourceMember가 탈퇴한 회원인 경우
+                content = "(탈퇴한 사용자)" + content;
+            } else {
+                content = notification.getSourceMember().getGameName() + content;
+            }
+
+        }
+
         return NotificationResponse.notificationDTO.builder()
             .notificationId(notification.getId())
             .notificationType(notification.getNotificationType().getId().intValue())
-            .content(notification.getContent())
+            .content(content)
             .pageUrl(pageUrl)
             .read(notification.isRead())
             .createdAt(notification.getCreatedAt().withNano(0))

--- a/src/main/java/com/gamegoo/domain/notification/Notification.java
+++ b/src/main/java/com/gamegoo/domain/notification/Notification.java
@@ -34,7 +34,10 @@ public class Notification extends BaseDateTimeEntity {
     @Column(nullable = false)
     private boolean isRead;
 
-    private Long sourceId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "source_member_id")
+    private Member sourceMember;
+
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/com/gamegoo/service/manner/MannerService.java
+++ b/src/main/java/com/gamegoo/service/manner/MannerService.java
@@ -105,9 +105,10 @@ public class MannerService {
 
         // 매너평가 등록됨 알림 전송
         // 등록된 매너 평가 키워드 string 생성
-        String mannerKeywordString = mannerRatingKeywordList.stream()
-            .map(MannerKeyword::getContents)
-            .collect(Collectors.joining(", "));
+        String mannerKeywordString = mannerRatingKeywordList.get(0).getContents();
+        if (mannerRatingKeywordList.size() > 1) {
+            mannerKeywordString += " 외 " + (mannerRatingKeywordList.size() - 1) + "개의";
+        }
 
         Notification ratedNotification = notificationService.createNotification(
             NotificationTypeTitle.MANNER_KEYWORD_RATED,
@@ -198,11 +199,12 @@ public class MannerService {
             mannerRatingKeywordRepository.save(mannerRatingKeyword);
         });
 
-        // 매너평가 등록됨 알림 전송
+        // 비매너평가 등록됨 알림 전송
         // 등록된 매너 평가 키워드 string 생성
-        String mannerKeywordString = mannerRatingKeywordList.stream()
-            .map(MannerKeyword::getContents)
-            .collect(Collectors.joining(", "));
+        String mannerKeywordString = mannerRatingKeywordList.get(0).getContents();
+        if (mannerRatingKeywordList.size() > 1) {
+            mannerKeywordString += " 외 " + (mannerRatingKeywordList.size() - 1) + "개의";
+        }
 
         Notification ratedNotification = notificationService.createNotification(
             NotificationTypeTitle.MANNER_KEYWORD_RATED,

--- a/src/main/java/com/gamegoo/service/member/FriendService.java
+++ b/src/main/java/com/gamegoo/service/member/FriendService.java
@@ -143,11 +143,11 @@ public class FriendService {
         // 친구 요청 알림 생성
         // member -> targetMember
         notificationService.createNotification(NotificationTypeTitle.FRIEND_REQUEST_SEND,
-            targetMember.getGameName(), null, member);
+            null, targetMember, member);
 
         // targetMember -> member
         notificationService.createNotification(NotificationTypeTitle.FRIEND_REQUEST_RECEIVED,
-            member.getGameName(), member.getId(), targetMember);
+            null, member, targetMember);
     }
 
     /**
@@ -226,7 +226,7 @@ public class FriendService {
 
         // targetMember에게 친구 요청 수락 알림 생성
         notificationService.createNotification(NotificationTypeTitle.FRIEND_REQUEST_ACCEPTED,
-            member.getGameName(), null, targetMember);
+            member.getGameName(), member, targetMember);
     }
 
     /**
@@ -259,7 +259,7 @@ public class FriendService {
 
         // targetMember에게 친구 요청 거절 알림 생성
         notificationService.createNotification(NotificationTypeTitle.FRIEND_REQUEST_REJECTED,
-            member.getGameName(), null, targetMember);
+            member.getGameName(), member, targetMember);
     }
 
     /**


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
알림 엔티티 수정 및 탈퇴한 사용자 소환사명 표시 추가

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- notification 엔티티 sourceId -> sourceMember로 변경
- 매너 평가 등록 알림: 키워드가 2개 이상인 경우, "~ 외 n개"로 알림 텍스트 저장되도록 변경
- sourceMember가 탈퇴한 경우, 알림 팝업/전체 목록 조회 API 응답에 (탈퇴한 사용자)로 표시되도록 변경

## ⏳ 작업 내용
- [x] 알림 엔티티 수정: source meber id를 저장하도록
- [x] 알림 등록 메소드 수정: 알림 텍스트 자체에 소환사명 넣지 않도록 변경
- [x] 알림 팝업/전체 목록 조회 API 응답에 탈퇴한 사용자 소환사명 표시 추가

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
