### PR TITLE
[Feat/218] 매칭 우선순위 세부 작업 진행 

### DIFF
--- a/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
@@ -49,24 +49,24 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 매칭 관련 에러
     MATCHING_STATUS_BAD_REQUEST(HttpStatus.BAD_REQUEST, "MATCH400",
-        "status는 SUCCESS, FAIL 둘 중 하나로만 변경이 가능합니다."),
+            "status는 SUCCESS, FAIL 둘 중 하나로만 변경이 가능합니다."),
     MATHCING_TYPE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "MATCH401",
-        "matchingType은 BASIC, PRECISE 둘 중 하나여야합니다."),
+            "matchingType은 BASIC, PRECISE 둘 중 하나여야합니다."),
     MATCHING_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH402", "해당 사용자의 매칭 정보가 없습니다."),
     MATCHING_FAILED_BY_BLOCK(HttpStatus.BAD_REQUEST, "MATCH403", "차단된 사용자끼리의 매칭은 불가능합니다."),
-
+    MATCHING_POSITION_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH404", "포지션 정보가 없습니다."),
 
     // Riot 관련 에러
     RIOT_NOT_FOUND(HttpStatus.NOT_FOUND, "RIOT404", "해당 Riot 계정이 존재하지 않습니다."),
     RIOT_MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "RIOTMATCH404",
-        "해당 Riot 계정의 매칭을 불러오는 도중 에러가 발생했습니다. 최근 100판 이내 이벤트 매칭 제외, 일반 매칭(일반게임,랭크게임,칼바람)을 많이 한 계정으로 다시 시도하세요."),
+            "해당 Riot 계정의 매칭을 불러오는 도중 에러가 발생했습니다. 최근 100판 이내 이벤트 매칭 제외, 일반 매칭(일반게임,랭크게임,칼바람)을 많이 한 계정으로 다시 시도하세요."),
     RIOT_PREFER_CHAMPION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "RIOTCHAMPION500",
-        "선호 챔피언을 연동하는 도중 에러가 발생했습니다"),
+            "선호 챔피언을 연동하는 도중 에러가 발생했습니다"),
     CHAMPION_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAMPION404", "해당 챔피언이 존재하지 않습니다."),
     RIOT_MEMBER_CONFLICT(HttpStatus.CONFLICT, "RIOT409", "해당 이메일 계정은 이미 다른 RIOT 계정과 연동되었습니다."),
     RIOT_ACCOUNT_CONFLICT(HttpStatus.CONFLICT, "RIOT409", "해당 RIOT 계정은 이미 다른 이메일과 연동되어있습니다."),
     RIOT_INSUFFICIENT_MATCHES(HttpStatus.NOT_FOUND, "RIOT404",
-        "해당 RIOT 계정은 최근 100판 이내에 솔로랭크, 자유랭크, 일반게임, 칼바람을 플레이한 적이 없기 때문에 선호하는 챔피언 3명을 정할 수 없습니다."),
+            "해당 RIOT 계정은 최근 100판 이내에 솔로랭크, 자유랭크, 일반게임, 칼바람을 플레이한 적이 없기 때문에 선호하는 챔피언 3명을 정할 수 없습니다."),
     RIOT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "RIOT500", "RIOT API 연동 중 에러가 발생했습니다."),
 
     // 차단 관련 에러
@@ -81,7 +81,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 게시판 글 작성 관련 에러
     BOARD_GAME_STYLE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "BOARD400",
-        "게임 스타일 선택 개수(최대 3개)를 초과했습니다."),
+            "게임 스타일 선택 개수(최대 3개)를 초과했습니다."),
     GAME_MODE_INVALID(HttpStatus.BAD_REQUEST, "BOARD401", "게임모드 값은 1~4만 가능합니다."),
     MAIN_POSITION_INVALID(HttpStatus.BAD_REQUEST, "BOARD401", "주포지션 값은 0~5만 가능합니다."),
     SUB_POSITION_INVALID(HttpStatus.BAD_REQUEST, "BOARD401", "부포지션 값은 0~5만 가능합니다."),
@@ -97,11 +97,11 @@ public enum ErrorStatus implements BaseErrorCode {
     // 매너평가 관련 에러
     MANNER_TARGET_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MANNER401", "매너 평가 대상 회원을 찾을 수 없습니다."),
     BAD_MANNER_TARGET_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MANNER401",
-        "비매너 평가 대상 회원을 찾을 수 없습니다."),
+            "비매너 평가 대상 회원을 찾을 수 없습니다."),
     MANNER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "MANNER401", "매너평가 작성자만 수정 가능합니다."),
     MANNER_KEYWORD_TYPE_INVALID(HttpStatus.BAD_REQUEST, "MANNER401", "매너 키워드 유형은 1~6만 가능합니다."),
     BAD_MANNER_KEYWORD_TYPE_INVALID(HttpStatus.BAD_REQUEST, "MANNER401",
-        "비매너 키워드 유형은 7~12만 가능합니다."),
+            "비매너 키워드 유형은 7~12만 가능합니다."),
     MANNER_KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "MANNER404", "해당 매너 키워드를 찾을 수 없습니다."),
     MANNER_NOT_FOUND(HttpStatus.NOT_FOUND, "MANNER404", "해당 매너평가를 찾을 수 없습니다."),
     BAD_MANNER_NOT_FOUND(HttpStatus.NOT_FOUND, "MANNER404", "해당 비매너평가를 찾을 수 없습니다."),
@@ -111,65 +111,65 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 채팅 관련 에러
     CHAT_START_FAILED_CHAT_TARGET_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT401",
-        "채팅 대상 회원을 찾을 수 없습니다."),
+            "채팅 대상 회원을 찾을 수 없습니다."),
     CHATROOM_NOT_EXIST(HttpStatus.NOT_FOUND, "CHAT402", "채팅방을 찾을 수 없습니다."),
     CHATROOM_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "CHAT403", "접근할 수 없는 채팅방 입니다."),
     CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT404", "해당 메시지를 찾을 수 없습니다"),
     CHAT_START_FAILED_CHAT_TARGET_IS_BLOCKED(HttpStatus.FORBIDDEN, "CHAT405",
-        "채팅 상대 회원을 차단한 상태입니다. 채팅 시작이 불가능합니다."),
+            "채팅 상대 회원을 차단한 상태입니다. 채팅 시작이 불가능합니다."),
     CHAT_START_FAILED_BLOCKED_BY_CHAT_TARGET(HttpStatus.FORBIDDEN, "CHAT406",
-        "채팅 상대 회원이 나를 차단했습니다. 채팅 시작이 불가능합니다."),
+            "채팅 상대 회원이 나를 차단했습니다. 채팅 시작이 불가능합니다."),
     CHAT_START_FAILED_TARGET_USER_DEACTIVATED(HttpStatus.NOT_FOUND, "CHAT407",
-        "채팅 상대 회원이 탈퇴했습니다. 채팅 시작이 불가능합니다."),
+            "채팅 상대 회원이 탈퇴했습니다. 채팅 시작이 불가능합니다."),
     CHAT_START_FAILED_BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT408",
-        "해당 게시글이 존재하지 않습니다. 채팅 시작이 불가능합니다."),
+            "해당 게시글이 존재하지 않습니다. 채팅 시작이 불가능합니다."),
     CHAT_START_FAILED_BOARD_CREATOR_IS_SELF(HttpStatus.BAD_REQUEST, "CHAT409",
-        "해당 게시글의 작성자가 본인입니다. 채팅 시작이 불가능합니다."),
+            "해당 게시글의 작성자가 본인입니다. 채팅 시작이 불가능합니다."),
     CHAT_START_FAILED_TARGET_USER_IS_SELF(HttpStatus.BAD_REQUEST, "CHAT410",
-        "채팅 대상 회원이 본인입니다. 채팅 시작이 불가능합니다."),
+            "채팅 대상 회원이 본인입니다. 채팅 시작이 불가능합니다."),
     CHAT_READ_FAILED_NOT_ENTERED_CHATROOM(HttpStatus.FORBIDDEN, "CHAT411",
-        "해당 채팅방에 입장 상태가 아닙니다. 채팅방 입장 후 메시지 읽음 처리하세요."),
+            "해당 채팅방에 입장 상태가 아닙니다. 채팅방 입장 후 메시지 읽음 처리하세요."),
     CHAT_READ_FAILED_CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT412",
-        "해당 메시지를 찾을 수 없습니다. 채팅 메시지 읽음 처리 실패"),
+            "해당 메시지를 찾을 수 없습니다. 채팅 메시지 읽음 처리 실패"),
     CHAT_ADD_FAILED_TARGET_USER_DEACTIVATED(HttpStatus.BAD_REQUEST, "CHAT413",
-        "채팅 상대 회원이 탈퇴했습니다. 채팅 전송이 불가능합니다."),
+            "채팅 상대 회원이 탈퇴했습니다. 채팅 전송이 불가능합니다."),
     CHAT_ADD_FAILED_CHAT_TARGET_IS_BLOCKED(HttpStatus.FORBIDDEN, "CHAT408",
-        "채팅 상대 회원을 차단한 상태입니다. 채팅 메시지 전송이 불가능합니다."),
+            "채팅 상대 회원을 차단한 상태입니다. 채팅 메시지 전송이 불가능합니다."),
     CHAT_ADD_FAILED_BLOCKED_BY_CHAT_TARGET(HttpStatus.FORBIDDEN, "CHAT409",
-        "채팅 상대 회원이 나를 차단했습니다. 채팅 메시지 전송이 불가능합니다."),
+            "채팅 상대 회원이 나를 차단했습니다. 채팅 메시지 전송이 불가능합니다."),
 
 
     // 친구 관련 에러
     FRIEND_BAD_REQUEST(HttpStatus.BAD_REQUEST, "FRIEND401", "잘못된 친구 요청입니다."),
     FRIEND_TARGET_IS_BLOCKED(HttpStatus.BAD_REQUEST, "FRIEND402",
-        "내가 차단한 회원입니다. 친구 요청을 보낼 수 없습니다."),
+            "내가 차단한 회원입니다. 친구 요청을 보낼 수 없습니다."),
     BLOCKED_BY_FRIEND_TARGET(HttpStatus.BAD_REQUEST, "FRIEND403",
-        "나를 차단한 회원입니다. 친구 요청을 보낼 수 없습니다."),
+            "나를 차단한 회원입니다. 친구 요청을 보낼 수 없습니다."),
     MY_PENDING_FRIEND_REQUEST_EXIST(HttpStatus.BAD_REQUEST, "FRIEND404",
-        "해당 회원에게 보낸 수락 대기 중인 친구 요청이 존재합니다. 친구 요청을 보낼 수 없습니다."),
+            "해당 회원에게 보낸 수락 대기 중인 친구 요청이 존재합니다. 친구 요청을 보낼 수 없습니다."),
     TARGET_PENDING_FRIEND_REQUEST_EXIST(HttpStatus.BAD_REQUEST, "FRIEND405",
-        "해당 회원이 나에게 보낸 친구 요청이 수락 대기 중 입니다. 해당 요청을 수락 해주세요."),
+            "해당 회원이 나에게 보낸 친구 요청이 수락 대기 중 입니다. 해당 요청을 수락 해주세요."),
     ALREADY_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND406",
-        "두 회원은 이미 친구 관계 입니다. 친구 요청을 보낼 수 없습니다."),
+            "두 회원은 이미 친구 관계 입니다. 친구 요청을 보낼 수 없습니다."),
     PENDING_FRIEND_REQUEST_NOT_EXIST(HttpStatus.NOT_FOUND, "FRIEND407",
-        "취소/수락/거절할 친구 요청이 존재하지 않습니다."),
+            "취소/수락/거절할 친구 요청이 존재하지 않습니다."),
     MEMBERS_NOT_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND408", "두 회원은 친구 관계가 아닙니다."),
     ALREADY_STAR_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND409", "이미 즐겨찾기 되어 있는 친구입니다."),
     NOT_STAR_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND410", "즐겨찾기 되어 있는 친구가 아닙니다."),
     FRIEND_SEARCH_QUERY_BAD_REQUEST(HttpStatus.BAD_REQUEST, "FRIEND411",
-        "친구 검색 쿼리는 100자 이하여야 합니다."),
+            "친구 검색 쿼리는 100자 이하여야 합니다."),
     FRIEND_USER_DEACTIVATED(HttpStatus.NOT_FOUND, "FRIEND412", "친구 회원이 탈퇴했습니다."),
 
     // 알림 관련 에러
     NOTIFICATION_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI401", "해당 알림 타입 데이터를 찾을 수 없습니다."),
     NOTIFICATION_METHOD_BAD_REQUEST(HttpStatus.BAD_REQUEST, "NOTI402", "알림 생성 메소드 호출이 잘못되었습니다."),
     INVALID_NOTIFICATION_TYPE(HttpStatus.BAD_REQUEST, "NOTI403",
-        "잘못된 알림 조회 타입입니다. general과 friend 중 하나를 입력하세요."),
+            "잘못된 알림 조회 타입입니다. general과 friend 중 하나를 입력하세요."),
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI404", "해당 알림 내역을 찾을 수 없습니다."),
 
     // SOCKET 서버 API 호출 에러
     SOCKET_API_RESPONSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SOCKET501",
-        "socket서버 api 요청에 실패했습니다.");
+            "socket서버 api 요청에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;
@@ -178,19 +178,19 @@ public enum ErrorStatus implements BaseErrorCode {
     @Override
     public ErrorReasonDTO getReason() {
         return ErrorReasonDTO.builder()
-            .message(message)
-            .code(code)
-            .isSuccess(false)
-            .build();
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
     }
 
     @Override
     public ErrorReasonDTO getReasonHttpStatus() {
         return ErrorReasonDTO.builder()
-            .message(message)
-            .code(code)
-            .isSuccess(false)
-            .httpStatus(httpStatus)
-            .build();
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
     }
 }

--- a/src/main/java/com/gamegoo/domain/matching/MatchingRecord.java
+++ b/src/main/java/com/gamegoo/domain/matching/MatchingRecord.java
@@ -23,13 +23,13 @@ public class MatchingRecord extends BaseDateTimeEntity {
     @Column(name = "game_mode", nullable = false)
     private Integer gameMode;
 
-    @Column(name = "main_position", nullable = false)
+    @Column(name = "main_position")
     private Integer mainPosition;
 
-    @Column(name = "sub_position", nullable = false)
+    @Column(name = "sub_position")
     private Integer subPosition;
 
-    @Column(name = "want_position", nullable = false)
+    @Column(name = "want_position")
     private Integer wantPosition;
 
     @Column(name = "mike", nullable = false)

--- a/src/main/java/com/gamegoo/dto/matching/MatchingRequest.java
+++ b/src/main/java/com/gamegoo/dto/matching/MatchingRequest.java
@@ -40,7 +40,6 @@ public class MatchingRequest {
         @Max(value = 5, message = "원하는 상대 포지션의 값은 5이하이어야합니다.")
         int wantP;
 
-        @NotNull(message = "gameStyleIdList는 비워둘 수 없습니다")
         List<Long> gameStyleIdList;
     }
 

--- a/src/main/java/com/gamegoo/dto/matching/MatchingRequest.java
+++ b/src/main/java/com/gamegoo/dto/matching/MatchingRequest.java
@@ -30,15 +30,15 @@ public class MatchingRequest {
 
         @Min(value = 0, message = "메인 포지션의 값은 0이상이어야 합니다.")
         @Max(value = 5, message = "메인 포지션의 값은 5이하이어야 합니다.")
-        int mainP;
+        Integer mainP;
 
         @Min(value = 0, message = "서브 포지션의 값은 0이상이어야 합니다.")
         @Max(value = 5, message = "서브 포지션의 값은 5이하이어야합니다.")
-        int subP;
+        Integer subP;
 
         @Min(value = 0, message = "원하는 상대 포지션의 값은 0이상이어야 합니다.")
         @Max(value = 5, message = "원하는 상대 포지션의 값은 5이하이어야합니다.")
-        int wantP;
+        Integer wantP;
 
         List<Long> gameStyleIdList;
     }

--- a/src/main/java/com/gamegoo/service/matching/MatchingService.java
+++ b/src/main/java/com/gamegoo/service/matching/MatchingService.java
@@ -215,22 +215,27 @@ public class MatchingService {
             }
 
             // 포지션 가중치
-            if (myWantPosition.equals(otherMainPosition) || myWantPosition.equals(0)
-                    || otherMainPosition.equals(0)) {
-                priority += 3;
-            } else if (myWantPosition.equals(otherSubPosition) || otherSubPosition.equals(0)) {
-                priority += 2;
+            // 칼바람 : 포지션 선택 제외하기 -> 포지션 점수 기본값으로 주고 시작하기
+            if (gameMode == 4) {
+                priority += 6;
             } else {
-                priority += 1;
-            }
+                if (myWantPosition.equals(otherMainPosition) || myWantPosition.equals(0)
+                        || otherMainPosition.equals(0)) {
+                    priority += 3;
+                } else if (myWantPosition.equals(otherSubPosition) || otherSubPosition.equals(0)) {
+                    priority += 2;
+                } else {
+                    priority += 1;
+                }
 
-            if (otherWantPosition.equals(myMainPosition) || otherWantPosition.equals(0)
-                    || myMainPosition.equals(0)) {
-                priority += 3;
-            } else if (otherWantPosition.equals(mySubPosition) || mySubPosition.equals(0)) {
-                priority += 2;
-            } else {
-                priority += 1;
+                if (otherWantPosition.equals(myMainPosition) || otherWantPosition.equals(0)
+                        || myMainPosition.equals(0)) {
+                    priority += 3;
+                } else if (otherWantPosition.equals(mySubPosition) || mySubPosition.equals(0)) {
+                    priority += 2;
+                } else {
+                    priority += 1;
+                }
             }
         }
 

--- a/src/main/java/com/gamegoo/service/matching/MatchingService.java
+++ b/src/main/java/com/gamegoo/service/matching/MatchingService.java
@@ -158,9 +158,26 @@ public class MatchingService {
             return 0;
         }
 
-        // 개인 랭크의 경우 티어 차이가 1개 이상 나면 X
+        // 개인 랭크 예외조건
         if (gameMode == 2) {
+            // 티어 차이가 1개 이상 나면 X
             if (Math.abs(myTier.ordinal() - otherTier.ordinal()) > 1) {
+                return 0;
+            }
+
+            // 마스터 이상은 게임 불가능
+            if (myTier.ordinal() >= 7 || otherTier.ordinal() >= 7) {
+                return 0;
+            }
+        }
+
+        // 자유랭크 예외조건
+        if (gameMode == 3) {
+            // 마스터 이상 플레이어는 골드 이하의 플레이어와 매칭 X
+            if (myTier.ordinal() >= 7 && otherTier.ordinal() <= 3) {
+                return 0;
+            }
+            if (otherTier.ordinal() >= 7 && myTier.ordinal() <= 3) {
                 return 0;
             }
         }
@@ -322,8 +339,12 @@ public class MatchingService {
                 .build();
 
         // 매칭 기록에 따라 member 정보 변경하기
-        member.updateMemberFromMatching(request.getMainP(), request.getSubP(), request.getMike());
-        profileService.addMemberGameStyles(request.getGameStyleIdList(), member.getId());
+        if (request.getMainP() != null && request.getSubP() != null && request.getWantP() != null) {
+            member.updateMemberFromMatching(request.getMainP(), request.getSubP(), request.getMike());
+        }
+        if (request.getGameStyleIdList() != null) {
+            profileService.addMemberGameStyles(request.getGameStyleIdList(), member.getId());
+        }
 
         matchingRecordRepository.save(matchingRecord);
         memberRepository.save(member);

--- a/src/main/java/com/gamegoo/service/matching/MatchingService.java
+++ b/src/main/java/com/gamegoo/service/matching/MatchingService.java
@@ -236,6 +236,11 @@ public class MatchingService {
             if (gameMode == 4) {
                 priority += 6;
             } else {
+                // 포지션 값이 Null일 경우 예외처리
+                if (myMainPosition == null || mySubPosition == null || myWantPosition == null) {
+                    throw new MatchingHandler(ErrorStatus.POSITION_NOT_FOUND);
+                }
+
                 if (myWantPosition.equals(otherMainPosition) || myWantPosition.equals(0)
                         || otherMainPosition.equals(0)) {
                     priority += 3;


### PR DESCRIPTION
## 🚀 개요
게임모드에 따른 매칭 우선순위 세부 작업 진행

## 🔍 변경사항
- 칼바람 우선순위 계산 변경
- 자유랭크 우선순위 계산 변경
- 개인랭크 우선순위 계산 변경

## ⏳ 작업 내용
- [x] 칼바람 : 포지션 선택 제외하기 -> 포지션 점수 기본값으로 주고 시작하기
- [x] 자유랭크 : 마스터 이상 플레이어는 골드 이하의 플레이어와 팀 구성할 수 없음
- [x] 자유랭크 : 골드 이하의 플레이어는 마스터 이상의 플레이어와 게임 불가능
- [x] 일반랭크 : 다이아 이하 구간이 마스터 이상 구간과 잡히지 않도록 예외처리
- [x] 일반랭크 : 마스터 이상 구간 -> 개인 랭크 못함
- [x] 주/부/ 원하는 포지션 값과 gameStyleIdList 값이 null이라도 에러 발생하지 않도록 처리

### 📝 논의사항
1. 랭크게임 조건 추가 + 레벨 30 이상, 보유 챔피언 20개 이상 참여 가능 확인하기
-> 불가능. 보유 챔피언이 20개 이상이라는 정보를 받아오는 API가 없음. 프론트측에서 팝업으로 알려주는 수밖에 없음
2. 일반랭크 : 다이아 이하 구간이 마스터 이상 구간과 잡히지 않도록 예외처리를 마스터 이상 구간이 있을 경우 무조건 우선순위 값을 0으로 하도록 처리함. 하지만 이 부분은 프론트에서 미리 예외처리 해서 API 요청하도록 수정해야함.