### PR TITLE
[Feat/217] 차단 목록 삭제 기능 구현

### DIFF
--- a/src/main/generated/com/gamegoo/domain/QBlock.java
+++ b/src/main/generated/com/gamegoo/domain/QBlock.java
@@ -33,6 +33,8 @@ public class QBlock extends EntityPathBase<Block> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
+    public final BooleanPath isDeleted = createBoolean("isDeleted");
+
     //inherited
     public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
 

--- a/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
@@ -74,6 +74,7 @@ public enum ErrorStatus implements BaseErrorCode {
     ALREADY_BLOCKED(HttpStatus.BAD_REQUEST, "BLOCK402", "이미 차단한 회원입니다."),
     TARGET_MEMBER_NOT_BLOCKED(HttpStatus.BAD_REQUEST, "BLOCK403", "차단 목록에 존재하지 않는 회원입니다."),
     BLOCK_MEMBER_BAD_REQUEST(HttpStatus.BAD_REQUEST, "BLOCK404", "잘못된 친구 차단 요청입니다."),
+    DELETE_BLOCKED_MEMBER_FAILED(HttpStatus.BAD_REQUEST, "BLOCK405", "차단 목록에서 삭제 불가한 회원입니다."),
 
     // 신고 관련 에러
     REPORT_TARGET_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT401", "신고 대상 회원을 찾을 수 없습니다."),

--- a/src/main/java/com/gamegoo/controller/member/BlockController.java
+++ b/src/main/java/com/gamegoo/controller/member/BlockController.java
@@ -44,7 +44,7 @@ public class BlockController {
     @Parameter(name = "page", description = "페이지 번호, 1 이상의 숫자를 입력해 주세요.")
     @GetMapping
     public ApiResponse<MemberResponse.blockListDTO> getBlockList(
-            @RequestParam(name = "page") Integer page) {
+        @RequestParam(name = "page") Integer page) {
         Long memberId = JWTUtil.getCurrentUserId();
 
         Page<Member> blockList = blockService.getBlockList(memberId, page - 1);
@@ -61,5 +61,17 @@ public class BlockController {
 
         return ApiResponse.onSuccess("차단 해제 성공");
     }
+
+    @Operation(summary = "차단 목록에서 해당 회원 삭제 API", description = "차단 목록에서 해당 회원을 삭제하는 API 입니다. (차단 해제 아님)")
+    @Parameter(name = "memberId", description = "목록에서 삭제할 대상 회원의 id 입니다.")
+    @DeleteMapping("/delete/{memberId}")
+    public ApiResponse<String> deleteBlockMember(
+        @PathVariable(name = "memberId") Long targetMemberId) {
+        Long memberId = JWTUtil.getCurrentUserId();
+        blockService.deleteBlockMember(memberId, targetMemberId);
+
+        return ApiResponse.onSuccess("차단 목록에서 삭제 성공");
+    }
+
 
 }

--- a/src/main/java/com/gamegoo/domain/Block.java
+++ b/src/main/java/com/gamegoo/domain/Block.java
@@ -1,10 +1,21 @@
 package com.gamegoo.domain;
 
-import com.gamegoo.domain.member.Member;
 import com.gamegoo.domain.common.BaseDateTimeEntity;
-import lombok.*;
-
-import javax.persistence.*;
+import com.gamegoo.domain.member.Member;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "Block")
@@ -13,10 +24,14 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Block extends BaseDateTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "block_id")
     private Long id;
+
+    @Column(nullable = false)
+    private Boolean isDeleted;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "blocker_id", nullable = false)

--- a/src/main/java/com/gamegoo/domain/Block.java
+++ b/src/main/java/com/gamegoo/domain/Block.java
@@ -56,4 +56,9 @@ public class Block extends BaseDateTimeEntity {
         blockerMember.getBlockList().remove(this);
         this.blockerMember = null;
     }
+
+    // Block 엔티티의 isDeleted를 변경하는 메소드
+    public void updateIsDeleted(Boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
 }

--- a/src/main/java/com/gamegoo/repository/member/MemberRepository.java
+++ b/src/main/java/com/gamegoo/repository/member/MemberRepository.java
@@ -1,16 +1,16 @@
 package com.gamegoo.repository.member;
 
 import com.gamegoo.domain.member.Member;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-import java.util.Optional;
-
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByGameName(String gameName);
@@ -19,8 +19,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByRefreshToken(String refresh_token);
 
-    @Query("SELECT m FROM Member m INNER JOIN Block b ON m.id = b.blockedMember.id WHERE b.blockerMember.id = :blockerId AND m.blind = false ORDER BY b.createdAt DESC")
-    Page<Member> findBlockedMembersByBlockerIdAndNotBlind(@Param("blockerId") Long blockerId, Pageable pageable);
+    @Query("SELECT m FROM Member m INNER JOIN Block b ON m.id = b.blockedMember.id WHERE b.blockerMember.id = :blockerId AND b.isDeleted = false ORDER BY b.createdAt DESC")
+    Page<Member> findBlockedMembersByBlockerIdAndNotDeleted(@Param("blockerId") Long blockerId,
+        Pageable pageable);
 
     List<Member> findAllByIdBetween(Long startId, Long endId);
 

--- a/src/main/java/com/gamegoo/service/member/BlockService.java
+++ b/src/main/java/com/gamegoo/service/member/BlockService.java
@@ -124,5 +124,30 @@ public class BlockService {
         blockRepository.delete(block);
     }
 
+    /**
+     * memberId에 해당하는 회원이 targetMemberId에 해당하는 회원을 자신의 차단 목록에서 삭제 처리 =
+     *
+     * @param memberId
+     * @param targetMemberId
+     */
+    public void deleteBlockMember(Long memberId, Long targetMemberId) {
+        // member 엔티티 조회
+        Member member = profileService.findMember(memberId);
+        Member targetMember = profileService.findMember(targetMemberId);
+
+        // targetMember가 차단 실제로 차단 목록에 존재하는지 검증
+        Block block = blockRepository.findByBlockerMemberAndBlockedMember(member, targetMember)
+            .orElseThrow(() -> new BlockHandler(ErrorStatus.TARGET_MEMBER_NOT_BLOCKED));
+
+        // targetMember가 탈퇴한 회원이 맞는지 검증
+        if (!targetMember.getBlind()) {
+            throw new BlockHandler(ErrorStatus.DELETE_BLOCKED_MEMBER_FAILED);
+        }
+
+        // Block 엔티티의 isDeleted 업데이트
+        block.updateIsDeleted(true);
+
+    }
+
 
 }

--- a/src/main/java/com/gamegoo/service/member/BlockService.java
+++ b/src/main/java/com/gamegoo/service/member/BlockService.java
@@ -60,6 +60,7 @@ public class BlockService {
 
         // block 엔티티 생성 및 연관관계 매핑
         Block block = Block.builder()
+            .isDeleted(false)
             .blockedMember(targetMember)
             .build();
         block.setBlockerMember(member);
@@ -100,7 +101,7 @@ public class BlockService {
 
         PageRequest pageRequest = PageRequest.of(pageIdx, PAGE_SIZE);
 
-        return memberRepository.findBlockedMembersByBlockerIdAndNotBlind(member.getId(),
+        return memberRepository.findBlockedMembersByBlockerIdAndNotDeleted(member.getId(),
             pageRequest);
     }
 


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
차단 목록에서 탈퇴한 회원을 안보이도록 삭제하는 기능 구현

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- Block 엔티티에 isDeleted 추가
- 차단 목록 조회 쿼리를 탈퇴한 회원도 조회되도록 변경
- 차단 목록에서 특정 회원 삭제 API 구현 

## ⏳ 작업 내용
- [x] Block 엔티티에 isDeleted 추가
- [x] 차단 목록 조회 쿼리를 탈퇴한 회원도 조회되도록 변경
- [x] 차단 목록에서 특정 회원 삭제 API 구현 

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
