### PR TITLE
[Feat/225] 매너 레벨 상승/하락 시 알림 등록 기능 추가

### DIFF
--- a/src/main/java/com/gamegoo/service/manner/MannerService.java
+++ b/src/main/java/com/gamegoo/service/manner/MannerService.java
@@ -307,7 +307,20 @@ public class MannerService {
             int mannerScore = updateMannerScore(targetMember);
 
             // 매너레벨 결정.
-            int mannerLevel = mannerLevel(mannerScore);
+            Integer mannerLevel = mannerLevel(mannerScore);
+
+            // 매너레벨 상승 알림 전송
+            if (targetMember.getMannerLevel() < mannerLevel) {
+                Notification mannerUpNotification = notificationService.createNotification(
+                    NotificationTypeTitle.MANNER_LEVEL_UP, mannerLevel.toString(),
+                    null, targetMember);
+                notificationRepository.save(mannerUpNotification);
+            } else if (targetMember.getMannerLevel() > mannerLevel) { // 매너레벨 하락 알림 전송
+                Notification mannerDownNotification = notificationService.createNotification(
+                    NotificationTypeTitle.MANNER_LEVEL_DOWN, mannerLevel.toString(),
+                    null, targetMember);
+                notificationRepository.save(mannerDownNotification);
+            }
 
             // 매너레벨 반영.
             targetMember.setMannerLevel(mannerLevel);
@@ -374,7 +387,20 @@ public class MannerService {
             int mannerScore = updateMannerScore(targetMember);
 
             // 매너레벨 결정.
-            int mannerLevel = mannerLevel(mannerScore);
+            Integer mannerLevel = mannerLevel(mannerScore);
+
+            // 매너레벨 상승 알림 전송
+            if (targetMember.getMannerLevel() < mannerLevel) {
+                Notification mannerUpNotification = notificationService.createNotification(
+                    NotificationTypeTitle.MANNER_LEVEL_UP, mannerLevel.toString(),
+                    null, targetMember);
+                notificationRepository.save(mannerUpNotification);
+            } else if (targetMember.getMannerLevel() > mannerLevel) { // 매너레벨 하락 알림 전송
+                Notification mannerDownNotification = notificationService.createNotification(
+                    NotificationTypeTitle.MANNER_LEVEL_DOWN, mannerLevel.toString(),
+                    null, targetMember);
+                notificationRepository.save(mannerDownNotification);
+            }
 
             // 매너레벨 반영.
             targetMember.setMannerLevel(mannerLevel);


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
기존 매너 평가 수정으로 인해 매너 레벨 상승/하락 시, 알림 등록 기능 추가

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 매너평가 수정 메소드에 알림 등록 코드 추가

## ⏳ 작업 내용
- [x] 매너평가 수정 메소드에 알림 등록 코드 추가

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
