### PR TITLE
[Refactor/227] 차단 도메인 회원 탈퇴 관련 로직 추가

### DIFF
--- a/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
@@ -49,9 +49,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 매칭 관련 에러
     MATCHING_STATUS_BAD_REQUEST(HttpStatus.BAD_REQUEST, "MATCH400",
-            "status는 SUCCESS, FAIL 둘 중 하나로만 변경이 가능합니다."),
+        "status는 SUCCESS, FAIL 둘 중 하나로만 변경이 가능합니다."),
     MATHCING_TYPE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "MATCH401",
-            "matchingType은 BASIC, PRECISE 둘 중 하나여야합니다."),
+        "matchingType은 BASIC, PRECISE 둘 중 하나여야합니다."),
     MATCHING_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH402", "해당 사용자의 매칭 정보가 없습니다."),
     MATCHING_FAILED_BY_BLOCK(HttpStatus.BAD_REQUEST, "MATCH403", "차단된 사용자끼리의 매칭은 불가능합니다."),
     MATCHING_POSITION_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH404", "포지션 정보가 없습니다."),
@@ -59,14 +59,14 @@ public enum ErrorStatus implements BaseErrorCode {
     // Riot 관련 에러
     RIOT_NOT_FOUND(HttpStatus.NOT_FOUND, "RIOT404", "해당 Riot 계정이 존재하지 않습니다."),
     RIOT_MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "RIOTMATCH404",
-            "해당 Riot 계정의 매칭을 불러오는 도중 에러가 발생했습니다. 최근 100판 이내 이벤트 매칭 제외, 일반 매칭(일반게임,랭크게임,칼바람)을 많이 한 계정으로 다시 시도하세요."),
+        "해당 Riot 계정의 매칭을 불러오는 도중 에러가 발생했습니다. 최근 100판 이내 이벤트 매칭 제외, 일반 매칭(일반게임,랭크게임,칼바람)을 많이 한 계정으로 다시 시도하세요."),
     RIOT_PREFER_CHAMPION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "RIOTCHAMPION500",
-            "선호 챔피언을 연동하는 도중 에러가 발생했습니다"),
+        "선호 챔피언을 연동하는 도중 에러가 발생했습니다"),
     CHAMPION_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAMPION404", "해당 챔피언이 존재하지 않습니다."),
     RIOT_MEMBER_CONFLICT(HttpStatus.CONFLICT, "RIOT409", "해당 이메일 계정은 이미 다른 RIOT 계정과 연동되었습니다."),
     RIOT_ACCOUNT_CONFLICT(HttpStatus.CONFLICT, "RIOT409", "해당 RIOT 계정은 이미 다른 이메일과 연동되어있습니다."),
     RIOT_INSUFFICIENT_MATCHES(HttpStatus.NOT_FOUND, "RIOT404",
-            "해당 RIOT 계정은 최근 100판 이내에 솔로랭크, 자유랭크, 일반게임, 칼바람을 플레이한 적이 없기 때문에 선호하는 챔피언 3명을 정할 수 없습니다."),
+        "해당 RIOT 계정은 최근 100판 이내에 솔로랭크, 자유랭크, 일반게임, 칼바람을 플레이한 적이 없기 때문에 선호하는 챔피언 3명을 정할 수 없습니다."),
     RIOT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "RIOT500", "RIOT API 연동 중 에러가 발생했습니다."),
 
     // 차단 관련 에러
@@ -75,6 +75,8 @@ public enum ErrorStatus implements BaseErrorCode {
     TARGET_MEMBER_NOT_BLOCKED(HttpStatus.BAD_REQUEST, "BLOCK403", "차단 목록에 존재하지 않는 회원입니다."),
     BLOCK_MEMBER_BAD_REQUEST(HttpStatus.BAD_REQUEST, "BLOCK404", "잘못된 친구 차단 요청입니다."),
     DELETE_BLOCKED_MEMBER_FAILED(HttpStatus.BAD_REQUEST, "BLOCK405", "차단 목록에서 삭제 불가한 회원입니다."),
+    UNBLOCK_TARGET_MEMBER_BLIND(HttpStatus.BAD_REQUEST, "BLOCK406",
+        "차단 대상 회원이 탈퇴했습니다. 차단 해제가 불가합니다."),
 
     // 신고 관련 에러
     REPORT_TARGET_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT401", "신고 대상 회원을 찾을 수 없습니다."),
@@ -82,7 +84,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 게시판 글 작성 관련 에러
     BOARD_GAME_STYLE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "BOARD400",
-            "게임 스타일 선택 개수(최대 3개)를 초과했습니다."),
+        "게임 스타일 선택 개수(최대 3개)를 초과했습니다."),
     GAME_MODE_INVALID(HttpStatus.BAD_REQUEST, "BOARD401", "게임모드 값은 1~4만 가능합니다."),
     MAIN_POSITION_INVALID(HttpStatus.BAD_REQUEST, "BOARD401", "주포지션 값은 0~5만 가능합니다."),
     SUB_POSITION_INVALID(HttpStatus.BAD_REQUEST, "BOARD401", "부포지션 값은 0~5만 가능합니다."),
@@ -98,11 +100,11 @@ public enum ErrorStatus implements BaseErrorCode {
     // 매너평가 관련 에러
     MANNER_TARGET_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MANNER401", "매너 평가 대상 회원을 찾을 수 없습니다."),
     BAD_MANNER_TARGET_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MANNER401",
-            "비매너 평가 대상 회원을 찾을 수 없습니다."),
+        "비매너 평가 대상 회원을 찾을 수 없습니다."),
     MANNER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "MANNER401", "매너평가 작성자만 수정 가능합니다."),
     MANNER_KEYWORD_TYPE_INVALID(HttpStatus.BAD_REQUEST, "MANNER401", "매너 키워드 유형은 1~6만 가능합니다."),
     BAD_MANNER_KEYWORD_TYPE_INVALID(HttpStatus.BAD_REQUEST, "MANNER401",
-            "비매너 키워드 유형은 7~12만 가능합니다."),
+        "비매너 키워드 유형은 7~12만 가능합니다."),
     MANNER_KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "MANNER404", "해당 매너 키워드를 찾을 수 없습니다."),
     MANNER_NOT_FOUND(HttpStatus.NOT_FOUND, "MANNER404", "해당 매너평가를 찾을 수 없습니다."),
     BAD_MANNER_NOT_FOUND(HttpStatus.NOT_FOUND, "MANNER404", "해당 비매너평가를 찾을 수 없습니다."),
@@ -112,65 +114,65 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 채팅 관련 에러
     CHAT_START_FAILED_CHAT_TARGET_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT401",
-            "채팅 대상 회원을 찾을 수 없습니다."),
+        "채팅 대상 회원을 찾을 수 없습니다."),
     CHATROOM_NOT_EXIST(HttpStatus.NOT_FOUND, "CHAT402", "채팅방을 찾을 수 없습니다."),
     CHATROOM_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "CHAT403", "접근할 수 없는 채팅방 입니다."),
     CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT404", "해당 메시지를 찾을 수 없습니다"),
     CHAT_START_FAILED_CHAT_TARGET_IS_BLOCKED(HttpStatus.FORBIDDEN, "CHAT405",
-            "채팅 상대 회원을 차단한 상태입니다. 채팅 시작이 불가능합니다."),
+        "채팅 상대 회원을 차단한 상태입니다. 채팅 시작이 불가능합니다."),
     CHAT_START_FAILED_BLOCKED_BY_CHAT_TARGET(HttpStatus.FORBIDDEN, "CHAT406",
-            "채팅 상대 회원이 나를 차단했습니다. 채팅 시작이 불가능합니다."),
+        "채팅 상대 회원이 나를 차단했습니다. 채팅 시작이 불가능합니다."),
     CHAT_START_FAILED_TARGET_USER_DEACTIVATED(HttpStatus.NOT_FOUND, "CHAT407",
-            "채팅 상대 회원이 탈퇴했습니다. 채팅 시작이 불가능합니다."),
+        "채팅 상대 회원이 탈퇴했습니다. 채팅 시작이 불가능합니다."),
     CHAT_START_FAILED_BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT408",
-            "해당 게시글이 존재하지 않습니다. 채팅 시작이 불가능합니다."),
+        "해당 게시글이 존재하지 않습니다. 채팅 시작이 불가능합니다."),
     CHAT_START_FAILED_BOARD_CREATOR_IS_SELF(HttpStatus.BAD_REQUEST, "CHAT409",
-            "해당 게시글의 작성자가 본인입니다. 채팅 시작이 불가능합니다."),
+        "해당 게시글의 작성자가 본인입니다. 채팅 시작이 불가능합니다."),
     CHAT_START_FAILED_TARGET_USER_IS_SELF(HttpStatus.BAD_REQUEST, "CHAT410",
-            "채팅 대상 회원이 본인입니다. 채팅 시작이 불가능합니다."),
+        "채팅 대상 회원이 본인입니다. 채팅 시작이 불가능합니다."),
     CHAT_READ_FAILED_NOT_ENTERED_CHATROOM(HttpStatus.FORBIDDEN, "CHAT411",
-            "해당 채팅방에 입장 상태가 아닙니다. 채팅방 입장 후 메시지 읽음 처리하세요."),
+        "해당 채팅방에 입장 상태가 아닙니다. 채팅방 입장 후 메시지 읽음 처리하세요."),
     CHAT_READ_FAILED_CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT412",
-            "해당 메시지를 찾을 수 없습니다. 채팅 메시지 읽음 처리 실패"),
+        "해당 메시지를 찾을 수 없습니다. 채팅 메시지 읽음 처리 실패"),
     CHAT_ADD_FAILED_TARGET_USER_DEACTIVATED(HttpStatus.BAD_REQUEST, "CHAT413",
-            "채팅 상대 회원이 탈퇴했습니다. 채팅 전송이 불가능합니다."),
+        "채팅 상대 회원이 탈퇴했습니다. 채팅 전송이 불가능합니다."),
     CHAT_ADD_FAILED_CHAT_TARGET_IS_BLOCKED(HttpStatus.FORBIDDEN, "CHAT408",
-            "채팅 상대 회원을 차단한 상태입니다. 채팅 메시지 전송이 불가능합니다."),
+        "채팅 상대 회원을 차단한 상태입니다. 채팅 메시지 전송이 불가능합니다."),
     CHAT_ADD_FAILED_BLOCKED_BY_CHAT_TARGET(HttpStatus.FORBIDDEN, "CHAT409",
-            "채팅 상대 회원이 나를 차단했습니다. 채팅 메시지 전송이 불가능합니다."),
+        "채팅 상대 회원이 나를 차단했습니다. 채팅 메시지 전송이 불가능합니다."),
 
 
     // 친구 관련 에러
     FRIEND_BAD_REQUEST(HttpStatus.BAD_REQUEST, "FRIEND401", "잘못된 친구 요청입니다."),
     FRIEND_TARGET_IS_BLOCKED(HttpStatus.BAD_REQUEST, "FRIEND402",
-            "내가 차단한 회원입니다. 친구 요청을 보낼 수 없습니다."),
+        "내가 차단한 회원입니다. 친구 요청을 보낼 수 없습니다."),
     BLOCKED_BY_FRIEND_TARGET(HttpStatus.BAD_REQUEST, "FRIEND403",
-            "나를 차단한 회원입니다. 친구 요청을 보낼 수 없습니다."),
+        "나를 차단한 회원입니다. 친구 요청을 보낼 수 없습니다."),
     MY_PENDING_FRIEND_REQUEST_EXIST(HttpStatus.BAD_REQUEST, "FRIEND404",
-            "해당 회원에게 보낸 수락 대기 중인 친구 요청이 존재합니다. 친구 요청을 보낼 수 없습니다."),
+        "해당 회원에게 보낸 수락 대기 중인 친구 요청이 존재합니다. 친구 요청을 보낼 수 없습니다."),
     TARGET_PENDING_FRIEND_REQUEST_EXIST(HttpStatus.BAD_REQUEST, "FRIEND405",
-            "해당 회원이 나에게 보낸 친구 요청이 수락 대기 중 입니다. 해당 요청을 수락 해주세요."),
+        "해당 회원이 나에게 보낸 친구 요청이 수락 대기 중 입니다. 해당 요청을 수락 해주세요."),
     ALREADY_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND406",
-            "두 회원은 이미 친구 관계 입니다. 친구 요청을 보낼 수 없습니다."),
+        "두 회원은 이미 친구 관계 입니다. 친구 요청을 보낼 수 없습니다."),
     PENDING_FRIEND_REQUEST_NOT_EXIST(HttpStatus.NOT_FOUND, "FRIEND407",
-            "취소/수락/거절할 친구 요청이 존재하지 않습니다."),
+        "취소/수락/거절할 친구 요청이 존재하지 않습니다."),
     MEMBERS_NOT_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND408", "두 회원은 친구 관계가 아닙니다."),
     ALREADY_STAR_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND409", "이미 즐겨찾기 되어 있는 친구입니다."),
     NOT_STAR_FRIEND(HttpStatus.BAD_REQUEST, "FRIEND410", "즐겨찾기 되어 있는 친구가 아닙니다."),
     FRIEND_SEARCH_QUERY_BAD_REQUEST(HttpStatus.BAD_REQUEST, "FRIEND411",
-            "친구 검색 쿼리는 100자 이하여야 합니다."),
+        "친구 검색 쿼리는 100자 이하여야 합니다."),
     FRIEND_USER_DEACTIVATED(HttpStatus.NOT_FOUND, "FRIEND412", "친구 회원이 탈퇴했습니다."),
 
     // 알림 관련 에러
     NOTIFICATION_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI401", "해당 알림 타입 데이터를 찾을 수 없습니다."),
     NOTIFICATION_METHOD_BAD_REQUEST(HttpStatus.BAD_REQUEST, "NOTI402", "알림 생성 메소드 호출이 잘못되었습니다."),
     INVALID_NOTIFICATION_TYPE(HttpStatus.BAD_REQUEST, "NOTI403",
-            "잘못된 알림 조회 타입입니다. general과 friend 중 하나를 입력하세요."),
+        "잘못된 알림 조회 타입입니다. general과 friend 중 하나를 입력하세요."),
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI404", "해당 알림 내역을 찾을 수 없습니다."),
 
     // SOCKET 서버 API 호출 에러
     SOCKET_API_RESPONSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SOCKET501",
-            "socket서버 api 요청에 실패했습니다.");
+        "socket서버 api 요청에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;
@@ -179,19 +181,19 @@ public enum ErrorStatus implements BaseErrorCode {
     @Override
     public ErrorReasonDTO getReason() {
         return ErrorReasonDTO.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(false)
-                .build();
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .build();
     }
 
     @Override
     public ErrorReasonDTO getReasonHttpStatus() {
         return ErrorReasonDTO.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(false)
-                .httpStatus(httpStatus)
-                .build();
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .httpStatus(httpStatus)
+            .build();
     }
 }

--- a/src/main/java/com/gamegoo/converter/MemberConverter.java
+++ b/src/main/java/com/gamegoo/converter/MemberConverter.java
@@ -33,7 +33,8 @@ public class MemberConverter {
             .memberId(member.getId())
             .profileImg(member.getProfileImage())
             .email(member.getEmail())
-            .name(member.getGameName())
+            .name(member.getBlind() ? "(탈퇴한 사용자)" : member.getGameName())
+            .isBlind(member.getBlind())
             .build();
 
     }

--- a/src/main/java/com/gamegoo/dto/member/MemberResponse.java
+++ b/src/main/java/com/gamegoo/dto/member/MemberResponse.java
@@ -35,6 +35,7 @@ public class MemberResponse {
         Integer profileImg;
         String email;
         String name;
+        Boolean isBlind;
     }
 
     @Getter

--- a/src/main/java/com/gamegoo/service/member/BlockService.java
+++ b/src/main/java/com/gamegoo/service/member/BlockService.java
@@ -116,6 +116,11 @@ public class BlockService {
         Member member = profileService.findMember(memberId);
         Member targetMember = profileService.findMember(targetMemberId);
 
+        // 대상 회원이 탈퇴 상태가 아닌지 검증
+        if (targetMember.getBlind()) {
+            throw new BlockHandler(ErrorStatus.UNBLOCK_TARGET_MEMBER_BLIND);
+        }
+
         // targetMember가 차단 실제로 차단 목록에 존재하는지 검증
         Block block = blockRepository.findByBlockerMemberAndBlockedMember(member, targetMember)
             .orElseThrow(() -> new BlockHandler(ErrorStatus.TARGET_MEMBER_NOT_BLOCKED));


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
차단 도메인 회원 탈퇴 관련 로직 추가

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 차단 목록 조회 API 응답에 상대 회원의 탈퇴 여부 추가
- 차단 해제 API 상대가 탈퇴한 회원인 경우 검증 추가, 관련 ErrorStatus 추가
- 차단 목록 조회 API 응답의 gameName(소환사명)을 해당 회원이 탈퇴했다면 (탈퇴한 사용자)로 넣도록

## ⏳ 작업 내용
- [x] 차단 목록 조회 API 응답에 상대 회원의 탈퇴 여부 추가
- [x] 차단 해제 API 상대가 탈퇴한 회원인 경우 검증 추가, 관련 ErrorStatus 추가
- [x] 차단 목록 조회 API 응답의 gameName(소환사명)을 해당 회원이 탈퇴했다면 (탈퇴한 사용자)로 넣도록

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
