### PR TITLE
[Feat/229] 매칭 성공 1시간 후 매너평가 시스템 메시지 전송 기능 구현

### DIFF
--- a/src/main/generated/com/gamegoo/domain/matching/QMatchingRecord.java
+++ b/src/main/generated/com/gamegoo/domain/matching/QMatchingRecord.java
@@ -35,6 +35,8 @@ public class QMatchingRecord extends EntityPathBase<MatchingRecord> {
 
     public final NumberPath<Integer> mannerLevel = createNumber("mannerLevel", Integer.class);
 
+    public final BooleanPath mannerMessageSent = createBoolean("mannerMessageSent");
+
     public final EnumPath<MatchingType> matchingType = createEnum("matchingType", MatchingType.class);
 
     public final com.gamegoo.domain.member.QMember member;
@@ -46,6 +48,8 @@ public class QMatchingRecord extends EntityPathBase<MatchingRecord> {
     public final EnumPath<MatchingStatus> status = createEnum("status", MatchingStatus.class);
 
     public final NumberPath<Integer> subPosition = createNumber("subPosition", Integer.class);
+
+    public final com.gamegoo.domain.member.QMember targetMember;
 
     public final EnumPath<com.gamegoo.domain.member.Tier> tier = createEnum("tier", com.gamegoo.domain.member.Tier.class);
 
@@ -75,6 +79,7 @@ public class QMatchingRecord extends EntityPathBase<MatchingRecord> {
     public QMatchingRecord(Class<? extends MatchingRecord> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
         this.member = inits.isInitialized("member") ? new com.gamegoo.domain.member.QMember(forProperty("member")) : null;
+        this.targetMember = inits.isInitialized("targetMember") ? new com.gamegoo.domain.member.QMember(forProperty("targetMember")) : null;
     }
 
 }

--- a/src/main/java/com/gamegoo/GamegooApplication.java
+++ b/src/main/java/com/gamegoo/GamegooApplication.java
@@ -3,9 +3,11 @@ package com.gamegoo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class GamegooApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/gamegoo/domain/matching/MatchingRecord.java
+++ b/src/main/java/com/gamegoo/domain/matching/MatchingRecord.java
@@ -3,9 +3,22 @@ package com.gamegoo.domain.matching;
 import com.gamegoo.domain.common.BaseDateTimeEntity;
 import com.gamegoo.domain.member.Member;
 import com.gamegoo.domain.member.Tier;
-import lombok.*;
-
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "MatchingRecord")
@@ -14,6 +27,7 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class MatchingRecord extends BaseDateTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "matching_id", nullable = false)
@@ -57,12 +71,27 @@ public class MatchingRecord extends BaseDateTimeEntity {
     @Column(name = "manner_level")
     private Integer mannerLevel;
 
+    private Boolean mannerMessageSent;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_member_id")
+    private Member targetMember;
+
     // status 변경
     public void updateStatus(MatchingStatus status) {
         this.status = status;
+    }
+
+    // targetMember 설정
+    public void updateTargetMember(Member member) {
+        this.targetMember = member;
+    }
+
+    public void updateMannerMessageSent(Boolean mannerMessageSent) {
+        this.mannerMessageSent = mannerMessageSent;
     }
 }

--- a/src/main/java/com/gamegoo/repository/matching/MatchingRecordRepository.java
+++ b/src/main/java/com/gamegoo/repository/matching/MatchingRecordRepository.java
@@ -3,23 +3,28 @@ package com.gamegoo.repository.matching;
 import com.gamegoo.domain.matching.MatchingRecord;
 import com.gamegoo.domain.matching.MatchingStatus;
 import com.gamegoo.domain.member.Member;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
 public interface MatchingRecordRepository extends JpaRepository<MatchingRecord, Long> {
 
-    Optional<MatchingRecord> findFirstByMemberAndGameModeOrderByUpdatedAtDesc(Member member, Integer gameMode);
+    Optional<MatchingRecord> findFirstByMemberAndGameModeOrderByUpdatedAtDesc(Member member,
+        Integer gameMode);
 
-    @Query("SELECT m FROM MatchingRecord m WHERE m.createdAt > :createdAt AND m.status = :status AND m.gameMode = :gameMode " +
+    @Query(
+        "SELECT m FROM MatchingRecord m WHERE m.createdAt > :createdAt AND m.status = :status AND m.gameMode = :gameMode "
+            +
             "AND m.id IN (SELECT MAX(mr.id) FROM MatchingRecord mr WHERE mr.createdAt > :createdAt AND mr.status = :status AND mr.gameMode = :gameMode GROUP BY mr.member)")
     List<MatchingRecord> findTopByCreatedAtAfterAndStatusAndGameModeGroupByMemberId(
-            @Param("createdAt") LocalDateTime createdAt,
-            @Param("status") MatchingStatus status,
-            @Param("gameMode") Integer gameMode
+        @Param("createdAt") LocalDateTime createdAt,
+        @Param("status") MatchingStatus status,
+        @Param("gameMode") Integer gameMode
     );
+
+    List<MatchingRecord> findByStatusAndMannerMessageSentAndUpdatedAtBefore(MatchingStatus status,
+        Boolean mannerMessageSent, LocalDateTime updatedAt);
 }

--- a/src/main/java/com/gamegoo/scheduler/SchedulerService.java
+++ b/src/main/java/com/gamegoo/scheduler/SchedulerService.java
@@ -55,7 +55,7 @@ public class SchedulerService {
 
                     // socket 서버에게 메시지 전송 API 요청
                     socketService.sendSystemMessage(matchingRecord.getMember().getId(),
-                        MANNER_SYSTEM_MESSAGE);
+                        chatroom.getUuid(), MANNER_SYSTEM_MESSAGE);
                 },
                 () -> log.info("Chatroom not found, member ID: {}, target member ID: {}",
                     matchingRecord.getMember().getId(), matchingRecord.getTargetMember().getId()));

--- a/src/main/java/com/gamegoo/scheduler/SchedulerService.java
+++ b/src/main/java/com/gamegoo/scheduler/SchedulerService.java
@@ -1,0 +1,57 @@
+package com.gamegoo.scheduler;
+
+import com.gamegoo.domain.chat.Chat;
+import com.gamegoo.domain.matching.MatchingRecord;
+import com.gamegoo.domain.matching.MatchingStatus;
+import com.gamegoo.repository.matching.MatchingRecordRepository;
+import com.gamegoo.service.chat.ChatCommandService;
+import com.gamegoo.service.chat.ChatQueryService;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SchedulerService {
+
+    private final MatchingRecordRepository matchingRecordRepository;
+    private final ChatCommandService chatCommandService;
+    private final ChatQueryService chatQueryService;
+    private static final Long MANNER_MESSAGE_TIME = 60L; // 매칭 성공 n초 이후의 엔티티 조회함
+    private static final String MANNER_SYSTEM_MESSAGE = "매칭은 어떠셨나요? 상대방의 매너를 평가해주세요!";
+
+
+    /**
+     * 매칭 성공 1시간이 경과한 경우, 두 사용자에게 매너평가 시스템 메시지 전송
+     */
+    @Transactional
+    @Scheduled(fixedRate = 1000 * 60) // 60초 주기로 실행
+    public void mannerSystemMessageRun() {
+        log.info("scheduler start");
+
+        // 매칭 성공 1분이 경과된 matchingRecord 엔티티 조회 (실제로는 60분으로 해야함)
+        LocalDateTime updatedTime = LocalDateTime.now().plusSeconds(MANNER_MESSAGE_TIME);
+        List<MatchingRecord> matchingRecordList = matchingRecordRepository.findByStatusAndMannerMessageSentAndUpdatedAtBefore(
+            MatchingStatus.SUCCESS, false, updatedTime);
+
+        matchingRecordList.forEach(matchingRecord -> {
+            chatQueryService.getChatroomByMembers(
+                matchingRecord.getMember(),
+                matchingRecord.getTargetMember()
+            ).ifPresentOrElse(
+                chatroom -> {
+                    Chat andSaveSystemChat = chatCommandService.createAndSaveSystemChat(
+                        chatroom, matchingRecord.getMember(), MANNER_SYSTEM_MESSAGE, null);
+                    matchingRecord.updateMannerMessageSent(true);
+                },
+                () -> log.info("Chatroom not found, member ID: {}, target member ID: {}",
+                    matchingRecord.getMember().getId(), matchingRecord.getTargetMember().getId()));
+        });
+
+    }
+}

--- a/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
@@ -518,7 +518,7 @@ public class ChatCommandService {
      * @param sourceBoard
      * @return
      */
-    private Chat createAndSaveSystemChat(Chatroom chatroom, Member toMember,
+    public Chat createAndSaveSystemChat(Chatroom chatroom, Member toMember,
         String content, Board sourceBoard) {
         Member systemMember = profileService.findSystemMember();
 

--- a/src/main/java/com/gamegoo/service/matching/MatchingService.java
+++ b/src/main/java/com/gamegoo/service/matching/MatchingService.java
@@ -16,13 +16,12 @@ import com.gamegoo.repository.matching.MatchingRecordRepository;
 import com.gamegoo.repository.member.BlockRepository;
 import com.gamegoo.repository.member.MemberRepository;
 import com.gamegoo.service.member.ProfileService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
-import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -42,34 +41,33 @@ public class MatchingService {
      * @throws MemberHandler
      */
     public MatchingResponse.PriorityMatchingResponseDTO getPriorityLists(
-            MatchingRequest.InitializingMatchingRequestDTO request, Long id) throws MemberHandler {
-
+        MatchingRequest.InitializingMatchingRequestDTO request, Long id) throws MemberHandler {
 
         // 게임 모드가 같고, 5분동안 매칭이 되지 않은 매칭 기록 가져오기
         LocalDateTime fiveMinutesAgo = LocalDateTime.now().minusMinutes(5);
         List<MatchingRecord> matchingRecords = matchingRecordRepository.findTopByCreatedAtAfterAndStatusAndGameModeGroupByMemberId(
-                fiveMinutesAgo, MatchingStatus.PENDING, request.getGameMode());
+            fiveMinutesAgo, MatchingStatus.PENDING, request.getGameMode());
 
         Member member = profileService.findMember(id);
 
         List<MemberPriority> otherPriorityList = new ArrayList<>();
         List<MemberPriority> myPriorityList = new ArrayList<>();
 
-
         MatchingRecord myMatchingRecord = MatchingRecord.builder()
-                .member(member)
-                .mike(request.getMike())
-                .rank(member.getRank())
-                .tier(member.getTier())
-                .winRate(member.getWinRate())
-                .status(MatchingStatus.PENDING)
-                .matchingType(MatchingType.valueOf(request.getMatchingType()))
-                .mainPosition(request.getMainP())
-                .subPosition(request.getSubP())
-                .wantPosition(request.getWantP())
-                .mannerLevel(member.getMannerLevel())
-                .gameMode(request.getGameMode())
-                .build();
+            .member(member)
+            .mike(request.getMike())
+            .rank(member.getRank())
+            .tier(member.getTier())
+            .winRate(member.getWinRate())
+            .status(MatchingStatus.PENDING)
+            .matchingType(MatchingType.valueOf(request.getMatchingType()))
+            .mainPosition(request.getMainP())
+            .subPosition(request.getSubP())
+            .wantPosition(request.getWantP())
+            .mannerLevel(member.getMannerLevel())
+            .gameMode(request.getGameMode())
+            .targetMember(null)
+            .build();
 
         // 우선순위 계산하기
         for (MatchingRecord record : matchingRecords) {
@@ -93,26 +91,26 @@ public class MatchingService {
 
         // 내 매칭 기록 dto 생성
         MatchingResponse.matchingRequestResponseDTO myMatchingInfo = matchingRequestResponseDTO.builder()
-                .memberId(member.getId())
-                .gameName(member.getGameName())
-                .tag(member.getTag())
-                .tier(member.getTier())
-                .rank(member.getRank())
-                .mannerLevel(member.getMannerLevel())
-                .profileImg(member.getProfileImage())
-                .gameMode(request.getGameMode())
-                .mainPosition(request.getMainP())
-                .subPosition(request.getSubP())
-                .wantPosition(request.getWantP())
-                .mike(request.getMike())
-                .gameStyleList(profileService.getGameStyleList(member))
-                .build();
+            .memberId(member.getId())
+            .gameName(member.getGameName())
+            .tag(member.getTag())
+            .tier(member.getTier())
+            .rank(member.getRank())
+            .mannerLevel(member.getMannerLevel())
+            .profileImg(member.getProfileImage())
+            .gameMode(request.getGameMode())
+            .mainPosition(request.getMainP())
+            .subPosition(request.getSubP())
+            .wantPosition(request.getWantP())
+            .mike(request.getMike())
+            .gameStyleList(profileService.getGameStyleList(member))
+            .build();
 
         return MatchingResponse.PriorityMatchingResponseDTO.builder()
-                .myPriorityList(myPriorityList)
-                .otherPriorityList(otherPriorityList)
-                .myMatchingInfo(myMatchingInfo)
-                .build();
+            .myPriorityList(myPriorityList)
+            .otherPriorityList(otherPriorityList)
+            .myMatchingInfo(myMatchingInfo)
+            .build();
     }
 
 
@@ -124,7 +122,7 @@ public class MatchingService {
      * @return
      */
     private int calculatePriority(MatchingRecord myMatchingRecord,
-                                  MatchingRecord otherMatchingRecord) {
+        MatchingRecord otherMatchingRecord) {
         int priority = 0;
 
         Integer myRank = myMatchingRecord.getRank();
@@ -153,8 +151,10 @@ public class MatchingService {
 
         // 주/부 포지션 조합이 같을 경우 X
         // 겹치는게 둘 중 하나라도 0일 경우는 X
-        if ((otherMainPosition.equals(myMainPosition) && otherSubPosition.equals(mySubPosition) && !(otherMainPosition.equals(0) || otherSubPosition.equals(0))) ||
-                (otherMainPosition.equals(mySubPosition) && otherSubPosition.equals(myMainPosition) && !(otherMainPosition.equals(0) || otherSubPosition.equals(0)))) {
+        if ((otherMainPosition.equals(myMainPosition) && otherSubPosition.equals(mySubPosition)
+            && !(otherMainPosition.equals(0) || otherSubPosition.equals(0))) ||
+            (otherMainPosition.equals(mySubPosition) && otherSubPosition.equals(myMainPosition)
+                && !(otherMainPosition.equals(0) || otherSubPosition.equals(0)))) {
             return 0;
         }
 
@@ -205,7 +205,7 @@ public class MatchingService {
 
             // 내가 원하는 포지션이 상대 포지션이 아닐 경우 return 0
             if (!otherMainPosition.equals(myWantPosition) && !otherSubPosition.equals(
-                    myWantPosition)) {
+                myWantPosition)) {
                 return 0;
             }
 
@@ -242,7 +242,7 @@ public class MatchingService {
                 }
 
                 if (myWantPosition.equals(otherMainPosition) || myWantPosition.equals(0)
-                        || otherMainPosition.equals(0)) {
+                    || otherMainPosition.equals(0)) {
                     priority += 3;
                 } else if (myWantPosition.equals(otherSubPosition) || otherSubPosition.equals(0)) {
                     priority += 2;
@@ -251,7 +251,7 @@ public class MatchingService {
                 }
 
                 if (otherWantPosition.equals(myMainPosition) || otherWantPosition.equals(0)
-                        || myMainPosition.equals(0)) {
+                    || myMainPosition.equals(0)) {
                     priority += 3;
                 } else if (otherWantPosition.equals(mySubPosition) || mySubPosition.equals(0)) {
                     priority += 2;
@@ -329,23 +329,25 @@ public class MatchingService {
 
         // 매칭 기록 저장
         MatchingRecord matchingRecord = MatchingRecord.builder()
-                .mike(request.getMike())
-                .tier(member.getTier())
-                .rank(member.getRank())
-                .matchingType(MatchingType.valueOf(request.getMatchingType()))
-                .status(MatchingStatus.PENDING)
-                .mainPosition(request.getMainP())
-                .subPosition(request.getSubP())
-                .wantPosition(request.getWantP())
-                .winRate(member.getWinRate())
-                .gameMode(request.getGameMode())
-                .mannerLevel(member.getMannerLevel())
-                .member(member)
-                .build();
+            .mike(request.getMike())
+            .tier(member.getTier())
+            .rank(member.getRank())
+            .matchingType(MatchingType.valueOf(request.getMatchingType()))
+            .status(MatchingStatus.PENDING)
+            .mainPosition(request.getMainP())
+            .subPosition(request.getSubP())
+            .wantPosition(request.getWantP())
+            .winRate(member.getWinRate())
+            .gameMode(request.getGameMode())
+            .mannerLevel(member.getMannerLevel())
+            .member(member)
+            .targetMember(null)
+            .build();
 
         // 매칭 기록에 따라 member 정보 변경하기
         if (request.getMainP() != null && request.getSubP() != null && request.getWantP() != null) {
-            member.updateMemberFromMatching(request.getMainP(), request.getSubP(), request.getMike());
+            member.updateMemberFromMatching(request.getMainP(), request.getSubP(),
+                request.getMike());
         }
         if (request.getGameStyleIdList() != null) {
             profileService.addMemberGameStyles(request.getGameStyleIdList(), member.getId());
@@ -368,8 +370,8 @@ public class MatchingService {
 
         // 매칭 기록 불러오기
         MatchingRecord matchingRecord = matchingRecordRepository.findFirstByMemberAndGameModeOrderByUpdatedAtDesc(
-                        member, request.getGameMode())
-                .orElseThrow(() -> new MatchingHandler(ErrorStatus.MATCHING_NOT_FOUND));
+                member, request.getGameMode())
+            .orElseThrow(() -> new MatchingHandler(ErrorStatus.MATCHING_NOT_FOUND));
 
         try {
             MatchingStatus status = MatchingStatus.valueOf(request.getStatus().toUpperCase());
@@ -391,7 +393,7 @@ public class MatchingService {
      */
     @Transactional
     public void updateBothStatus(MatchingRequest.ModifyMatchingRequestDTO request, Long memberId,
-                                 Long targetMemberId) {
+        Long targetMemberId) {
 
         // request 값 검증
         MatchingStatus status;
@@ -408,14 +410,14 @@ public class MatchingService {
 
         // member의 매칭 기록 상태 변경
         MatchingRecord matchingRecord = matchingRecordRepository.findFirstByMemberAndGameModeOrderByUpdatedAtDesc(
-                        member, request.getGameMode())
-                .orElseThrow(() -> new MatchingHandler(ErrorStatus.MATCHING_NOT_FOUND));
+                member, request.getGameMode())
+            .orElseThrow(() -> new MatchingHandler(ErrorStatus.MATCHING_NOT_FOUND));
         matchingRecord.updateStatus(status);
 
         // targetMember의 매칭 기록 상태 변경
         MatchingRecord targetMatchingRecord = matchingRecordRepository.findFirstByMemberAndGameModeOrderByUpdatedAtDesc(
-                        targetMember, request.getGameMode())
-                .orElseThrow(() -> new MatchingHandler(ErrorStatus.MATCHING_NOT_FOUND));
+                targetMember, request.getGameMode())
+            .orElseThrow(() -> new MatchingHandler(ErrorStatus.MATCHING_NOT_FOUND));
         targetMatchingRecord.updateStatus(status);
     }
 
@@ -426,7 +428,7 @@ public class MatchingService {
      */
     @Transactional
     public MatchingResponse.matchingFoundResponseDTO foundMatching(Long memberId,
-                                                                   Long targetMemberId, int gameMode) {
+        Long targetMemberId, int gameMode) {
 
         // member 엔티티 조회
         Member member = profileService.findMember(memberId);
@@ -434,53 +436,53 @@ public class MatchingService {
 
         // member의 매칭 기록 상태 변경
         MatchingRecord matchingRecord = matchingRecordRepository.findFirstByMemberAndGameModeOrderByUpdatedAtDesc(
-                        member, gameMode)
-                .orElseThrow(() -> new MatchingHandler(ErrorStatus.MATCHING_NOT_FOUND));
+                member, gameMode)
+            .orElseThrow(() -> new MatchingHandler(ErrorStatus.MATCHING_NOT_FOUND));
         matchingRecord.updateStatus(MatchingStatus.FOUND);
 
         // targetMember의 매칭 기록 상태 변경
         MatchingRecord targetMatchingRecord = matchingRecordRepository.findFirstByMemberAndGameModeOrderByUpdatedAtDesc(
-                        targetMember, gameMode)
-                .orElseThrow(() -> new MatchingHandler(ErrorStatus.MATCHING_NOT_FOUND));
+                targetMember, gameMode)
+            .orElseThrow(() -> new MatchingHandler(ErrorStatus.MATCHING_NOT_FOUND));
         targetMatchingRecord.updateStatus(MatchingStatus.FOUND);
 
         // response dto 생성
         MatchingResponse.matchingRequestResponseDTO myMatchingInfo = matchingRequestResponseDTO.builder()
-                .memberId(member.getId())
-                .gameName(member.getGameName())
-                .tag(member.getTag())
-                .tier(member.getTier())
-                .rank(matchingRecord.getRank())
-                .mannerLevel(matchingRecord.getMannerLevel())
-                .profileImg(member.getProfileImage())
-                .gameMode(matchingRecord.getGameMode())
-                .mainPosition(matchingRecord.getMainPosition())
-                .subPosition(matchingRecord.getSubPosition())
-                .wantPosition(matchingRecord.getWantPosition())
-                .mike(matchingRecord.getMike())
-                .gameStyleList(profileService.getGameStyleList(member))
-                .build();
+            .memberId(member.getId())
+            .gameName(member.getGameName())
+            .tag(member.getTag())
+            .tier(member.getTier())
+            .rank(matchingRecord.getRank())
+            .mannerLevel(matchingRecord.getMannerLevel())
+            .profileImg(member.getProfileImage())
+            .gameMode(matchingRecord.getGameMode())
+            .mainPosition(matchingRecord.getMainPosition())
+            .subPosition(matchingRecord.getSubPosition())
+            .wantPosition(matchingRecord.getWantPosition())
+            .mike(matchingRecord.getMike())
+            .gameStyleList(profileService.getGameStyleList(member))
+            .build();
 
         MatchingResponse.matchingRequestResponseDTO targetMatchingInfo = matchingRequestResponseDTO.builder()
-                .memberId(targetMember.getId())
-                .gameName(targetMember.getGameName())
-                .tag(targetMember.getTag())
-                .tier(targetMember.getTier())
-                .rank(targetMatchingRecord.getRank())
-                .mannerLevel(targetMatchingRecord.getMannerLevel())
-                .profileImg(targetMember.getProfileImage())
-                .gameMode(targetMatchingRecord.getGameMode())
-                .mainPosition(targetMatchingRecord.getMainPosition())
-                .subPosition(targetMatchingRecord.getSubPosition())
-                .wantPosition(targetMatchingRecord.getWantPosition())
-                .mike(targetMatchingRecord.getMike())
-                .gameStyleList(profileService.getGameStyleList(targetMember))
-                .build();
+            .memberId(targetMember.getId())
+            .gameName(targetMember.getGameName())
+            .tag(targetMember.getTag())
+            .tier(targetMember.getTier())
+            .rank(targetMatchingRecord.getRank())
+            .mannerLevel(targetMatchingRecord.getMannerLevel())
+            .profileImg(targetMember.getProfileImage())
+            .gameMode(targetMatchingRecord.getGameMode())
+            .mainPosition(targetMatchingRecord.getMainPosition())
+            .subPosition(targetMatchingRecord.getSubPosition())
+            .wantPosition(targetMatchingRecord.getWantPosition())
+            .mike(targetMatchingRecord.getMike())
+            .gameStyleList(profileService.getGameStyleList(targetMember))
+            .build();
 
         return MatchingResponse.matchingFoundResponseDTO.builder()
-                .myMatchingInfo(myMatchingInfo)
-                .targetMatchingInfo(targetMatchingInfo)
-                .build();
+            .myMatchingInfo(myMatchingInfo)
+            .targetMatchingInfo(targetMatchingInfo)
+            .build();
 
     }
 
@@ -499,15 +501,19 @@ public class MatchingService {
 
         // member의 매칭 기록 상태 변경
         MatchingRecord matchingRecord = matchingRecordRepository.findFirstByMemberAndGameModeOrderByUpdatedAtDesc(
-                        member, gameMode)
-                .orElseThrow(() -> new MatchingHandler(ErrorStatus.MATCHING_NOT_FOUND));
+                member, gameMode)
+            .orElseThrow(() -> new MatchingHandler(ErrorStatus.MATCHING_NOT_FOUND));
         matchingRecord.updateStatus(MatchingStatus.SUCCESS);
+        matchingRecord.updateTargetMember(targetMember);
+        matchingRecord.updateMannerMessageSent(false);
 
         // targetMember의 매칭 기록 상태 변경
         MatchingRecord targetMatchingRecord = matchingRecordRepository.findFirstByMemberAndGameModeOrderByUpdatedAtDesc(
-                        targetMember, gameMode)
-                .orElseThrow(() -> new MatchingHandler(ErrorStatus.MATCHING_NOT_FOUND));
+                targetMember, gameMode)
+            .orElseThrow(() -> new MatchingHandler(ErrorStatus.MATCHING_NOT_FOUND));
         targetMatchingRecord.updateStatus(MatchingStatus.SUCCESS);
+        targetMatchingRecord.updateTargetMember(member);
+        targetMatchingRecord.updateMannerMessageSent(false);
     }
 }
 

--- a/src/main/java/com/gamegoo/service/socket/SocketService.java
+++ b/src/main/java/com/gamegoo/service/socket/SocketService.java
@@ -49,8 +49,32 @@ public class SocketService {
                 log.info("joinSocketToChatroom API call SUCCESS: {}", response.getBody());
             }
         } catch (Exception e) {
-            log.error("Error occurred while notifyChatroomEntered method", e);
+            log.error("Error occurred while joinSocketToChatroom method", e);
             throw new SocketHandler(ErrorStatus.SOCKET_API_RESPONSE_ERROR);
         }
+    }
+
+    public void sendSystemMessage(Long memberId, String content) {
+        String url = SOCKET_SERVER_URL + "/socket/sysmessage";
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("memberId", memberId);
+        requestBody.put("content", content);
+
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(url, requestBody,
+                String.class);
+
+            log.info("response of joinSocketToChatroom: {}", response.getStatusCode().toString());
+            if (!response.getStatusCode().equals(HttpStatus.OK)) {
+                log.error("joinSocketToChatroom API call FAIL: {}", response.getBody());
+                throw new SocketHandler(ErrorStatus.SOCKET_API_RESPONSE_ERROR);
+            } else {
+                log.info("joinSocketToChatroom API call SUCCESS: {}", response.getBody());
+            }
+        } catch (Exception e) {
+            log.error("Error occurred while sendSystemMessage method", e);
+            throw new SocketHandler(ErrorStatus.SOCKET_API_RESPONSE_ERROR);
+        }
+
     }
 }

--- a/src/main/java/com/gamegoo/service/socket/SocketService.java
+++ b/src/main/java/com/gamegoo/service/socket/SocketService.java
@@ -54,10 +54,11 @@ public class SocketService {
         }
     }
 
-    public void sendSystemMessage(Long memberId, String content) {
+    public void sendSystemMessage(Long memberId, String chatroomUuid, String content) {
         String url = SOCKET_SERVER_URL + "/socket/sysmessage";
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("memberId", memberId);
+        requestBody.put("chatroomUuid", chatroomUuid);
         requestBody.put("content", content);
 
         try {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,8 +21,8 @@ spring:
       hibernate:
         jdbc:
           time_zone: Asia/Seoul
-      show_sql: true
-      format_sql: true
+        #show_sql: true
+        #format_sql: true
     database-platform: org.hibernate.dialect.MariaDB103Dialect
 
 


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
매칭 성공 1시간 후 매너평가 시스템 메시지 전송 기능 구현

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- MatchingRecord 엔티티에 칼럼 추가
- socket 서버 시스템 메시지 전송 API 요청 메소드 추가
- 매칭 성공 후 특정 시간 경과 시 매너평가 메시지 생성 및 저장, socket API 요청 scheduler 구현

## ⏳ 작업 내용
- [x] MatchingRecord 엔티티에 칼럼 추가
- [x] socket 서버 시스템 메시지 전송 API 요청 메소드 추가
- [x] 매칭 성공 후 특정 시간 경과 시 매너평가 메시지 생성 및 저장, socket API 요청 scheduler 구현

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
