### PR TITLE
[Feat/232] 회원 탈퇴 API에 채팅, 친구 관련 로직 추가

### DIFF
--- a/src/main/java/com/gamegoo/repository/friend/FriendRequestsRepository.java
+++ b/src/main/java/com/gamegoo/repository/friend/FriendRequestsRepository.java
@@ -3,6 +3,7 @@ package com.gamegoo.repository.friend;
 import com.gamegoo.domain.friend.FriendRequestStatus;
 import com.gamegoo.domain.friend.FriendRequests;
 import com.gamegoo.domain.member.Member;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,4 +12,9 @@ public interface FriendRequestsRepository extends JpaRepository<FriendRequests, 
     Optional<FriendRequests> findByFromMemberAndToMemberAndStatus(Member fromMember,
         Member toMember, FriendRequestStatus status);
 
+    List<FriendRequests> findAllByFromMemberAndStatus(Member fromMember,
+        FriendRequestStatus status);
+
+    List<FriendRequests> findAllByToMemberAndStatus(Member toMember,
+        FriendRequestStatus status);
 }

--- a/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
+++ b/src/main/java/com/gamegoo/service/chat/ChatCommandService.java
@@ -19,7 +19,6 @@ import com.gamegoo.repository.chat.ChatRepository;
 import com.gamegoo.repository.chat.ChatroomRepository;
 import com.gamegoo.repository.chat.MemberChatroomRepository;
 import com.gamegoo.repository.member.MemberRepository;
-import com.gamegoo.service.board.BoardService;
 import com.gamegoo.service.member.FriendService;
 import com.gamegoo.service.member.ProfileService;
 import com.gamegoo.service.socket.SocketService;
@@ -41,7 +40,6 @@ public class ChatCommandService {
     private final ProfileService profileService;
     private final FriendService friendService;
     private final SocketService socketService;
-    private final BoardService boardService;
     private final MemberRepository memberRepository;
     private final MemberChatroomRepository memberChatroomRepository;
     private final ChatroomRepository chatroomRepository;
@@ -348,7 +346,6 @@ public class ChatCommandService {
         memberChatroom.updateLastJoinDate(null);
 
     }
-
 
     /* private 메소드 */
 

--- a/src/main/java/com/gamegoo/service/member/ProfileService.java
+++ b/src/main/java/com/gamegoo/service/member/ProfileService.java
@@ -3,12 +3,15 @@ package com.gamegoo.service.member;
 import com.gamegoo.apiPayload.code.status.ErrorStatus;
 import com.gamegoo.apiPayload.exception.handler.MemberHandler;
 import com.gamegoo.converter.MemberConverter;
+import com.gamegoo.domain.chat.MemberChatroom;
 import com.gamegoo.domain.friend.Friend;
 import com.gamegoo.domain.friend.FriendRequestStatus;
+import com.gamegoo.domain.friend.FriendRequests;
 import com.gamegoo.domain.gamestyle.GameStyle;
 import com.gamegoo.domain.gamestyle.MemberGameStyle;
 import com.gamegoo.domain.member.Member;
 import com.gamegoo.dto.member.MemberResponse;
+import com.gamegoo.repository.chat.MemberChatroomRepository;
 import com.gamegoo.repository.friend.FriendRepository;
 import com.gamegoo.repository.friend.FriendRequestsRepository;
 import com.gamegoo.repository.member.GameStyleRepository;
@@ -31,6 +34,8 @@ public class ProfileService {
 
     private final FriendRepository friendRepository;
     private final FriendRequestsRepository friendRequestsRepository;
+
+    private final MemberChatroomRepository memberChatroomRepository;
 
     /**
      * MemberGameStyle 데이터 추가 : 회원에 따른 게임 스타일 정보 저장하기
@@ -94,6 +99,25 @@ public class ProfileService {
 
         // Blind 처리
         member.deactiveMember();
+
+        // 해당 회원이 속한 모든 채팅방에서 퇴장 처리
+        List<MemberChatroom> allActiveMemberChatroom = memberChatroomRepository.findAllActiveMemberChatroom(
+            member.getId());
+        allActiveMemberChatroom.forEach(memberChatroom -> {
+            memberChatroom.updateLastJoinDate(null);
+        });
+
+        // 해당 회원이 보낸 모든 친구 요청 취소 처리
+        List<FriendRequests> sendFriendRequestsList = friendRequestsRepository.findAllByFromMemberAndStatus(
+            member, FriendRequestStatus.PENDING);
+        sendFriendRequestsList.forEach(
+            friendRequests -> friendRequests.updateStatus(FriendRequestStatus.CANCELLED));
+
+        // 해당 회원이 받은 모든 친구 요청 취소 처리
+        List<FriendRequests> receivedFriendRequestsList = friendRequestsRepository.findAllByToMemberAndStatus(
+            member, FriendRequestStatus.PENDING);
+        receivedFriendRequestsList.forEach(
+            friendRequests -> friendRequests.updateStatus(FriendRequestStatus.CANCELLED));
 
         memberRepository.save(member);
     }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
회원 탈퇴 API에 채팅, 친구 관련 로직 추가

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 탈퇴자가 속한 모든 채팅방에서 퇴장처리
- 탈퇴자가 보낸 모든 친구요청 취소 처리
- 탈퇴자가 받은 모든 친구요청 취소 처리

## ⏳ 작업 내용
- [x] 탈퇴자가 속한 모든 채팅방에서 퇴장처리
- [x] 탈퇴자가 보낸 모든 친구요청 취소 처리
- [x] 탈퇴자가 받은 모든 친구요청 취소 처리

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
