### PR TITLE
[Feat/236] 게시판 도메인 회원 탈퇴 관련 로직 추가

### DIFF
--- a/src/main/generated/com/gamegoo/domain/board/QBoard.java
+++ b/src/main/generated/com/gamegoo/domain/board/QBoard.java
@@ -33,6 +33,8 @@ public class QBoard extends EntityPathBase<Board> {
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
 
+    public final BooleanPath deleted = createBoolean("deleted");
+
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
     public final NumberPath<Integer> mainPosition = createNumber("mainPosition", Integer.class);

--- a/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
@@ -97,6 +97,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 게시판 글 삭제 관련 에러
     BOARD_DELETE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "BOARD401", "글 작성자만 삭제 가능합니다."),
+    BOARD_DELETED(HttpStatus.NOT_FOUND, "BOARD404", "해당 글은 삭제된 글입니다."),
 
     // 매너평가 관련 에러
     MANNER_TARGET_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MANNER401", "매너 평가 대상 회원을 찾을 수 없습니다."),

--- a/src/main/java/com/gamegoo/domain/board/Board.java
+++ b/src/main/java/com/gamegoo/domain/board/Board.java
@@ -42,6 +42,9 @@ public class Board extends BaseDateTimeEntity {
     @Column(name = "board_profile_image")
     private Integer boardProfileImage;
 
+    @Column(name = "deleted")
+    private Boolean deleted = false;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;

--- a/src/main/java/com/gamegoo/repository/board/BoardRepository.java
+++ b/src/main/java/com/gamegoo/repository/board/BoardRepository.java
@@ -5,23 +5,33 @@ import com.gamegoo.domain.member.Tier;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<Board,Long>{
     Page<Board> findByMemberId(Long memberId, Pageable pageable);
 
     @Query("SELECT b From Board b JOIN b.member m WHERE" +
+            "(b.deleted = false) AND " +
             "(:mode IS NULL OR b.mode = :mode) AND " +
             "(:tier IS NULL OR m.tier = :tier) AND " +
             "(:mainPosition IS NULL OR b.mainPosition = :mainPosition OR b.subPosition = :mainPosition) AND " +
             "(:mike IS NULL OR b.mike = :mike)")
-
     Page<Board> findByFilters(@Param("mode") Integer mode,
                               @Param("tier") Tier tier,
                               @Param("mainPosition") Integer mainPosition,
                               @Param("mike") Boolean mike,
                               Pageable pageable);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Board b SET b.deleted = true WHERE b.member.id = :memberId")
+    void deleteByMemberId(@Param("memberId") Long memberId);
+
+    Optional<Board> findByIdAndDeletedFalse(@Param("boardId") Long boardId);
 }

--- a/src/main/java/com/gamegoo/service/board/BoardService.java
+++ b/src/main/java/com/gamegoo/service/board/BoardService.java
@@ -305,8 +305,11 @@ public class BoardService {
     @Transactional(readOnly = true)
     public BoardResponse.boardByIdResponseDTO getBoardById(Long boardId) {
 
-        Board board = boardRepository.findById(boardId)
+        boardRepository.findById(boardId)
                 .orElseThrow(() -> new BoardHandler(ErrorStatus.BOARD_NOT_FOUND));
+
+        Board board = boardRepository.findByIdAndDeletedFalse(boardId)
+                .orElseThrow(() -> new BoardHandler(ErrorStatus.BOARD_DELETED));
 
         Member poster = board.getMember();
 
@@ -351,8 +354,11 @@ public class BoardService {
     public BoardResponse.boardByIdResponseForMemberDTO getBoardByIdForMember(Long boardId,
                                                                              Long memberId) {
 
-        Board board = boardRepository.findById(boardId)
+        boardRepository.findById(boardId)
                 .orElseThrow(() -> new BoardHandler(ErrorStatus.BOARD_NOT_FOUND));
+
+        Board board = boardRepository.findByIdAndDeletedFalse(boardId)
+                .orElseThrow(() -> new BoardHandler(ErrorStatus.BOARD_DELETED));
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));

--- a/src/main/java/com/gamegoo/service/board/BoardService.java
+++ b/src/main/java/com/gamegoo/service/board/BoardService.java
@@ -305,11 +305,12 @@ public class BoardService {
     @Transactional(readOnly = true)
     public BoardResponse.boardByIdResponseDTO getBoardById(Long boardId) {
 
-        boardRepository.findById(boardId)
+        Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new BoardHandler(ErrorStatus.BOARD_NOT_FOUND));
 
-        Board board = boardRepository.findByIdAndDeletedFalse(boardId)
-                .orElseThrow(() -> new BoardHandler(ErrorStatus.BOARD_DELETED));
+        if(board.getDeleted()){
+            throw new BoardHandler(ErrorStatus.BOARD_DELETED);
+        }
 
         Member poster = board.getMember();
 
@@ -354,11 +355,12 @@ public class BoardService {
     public BoardResponse.boardByIdResponseForMemberDTO getBoardByIdForMember(Long boardId,
                                                                              Long memberId) {
 
-        boardRepository.findById(boardId)
+        Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new BoardHandler(ErrorStatus.BOARD_NOT_FOUND));
 
-        Board board = boardRepository.findByIdAndDeletedFalse(boardId)
-                .orElseThrow(() -> new BoardHandler(ErrorStatus.BOARD_DELETED));
+        if (board.getDeleted()){
+            throw new BoardHandler(ErrorStatus.BOARD_DELETED);
+        }
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));

--- a/src/main/java/com/gamegoo/service/member/ProfileService.java
+++ b/src/main/java/com/gamegoo/service/member/ProfileService.java
@@ -11,6 +11,7 @@ import com.gamegoo.domain.gamestyle.GameStyle;
 import com.gamegoo.domain.gamestyle.MemberGameStyle;
 import com.gamegoo.domain.member.Member;
 import com.gamegoo.dto.member.MemberResponse;
+import com.gamegoo.repository.board.BoardRepository;
 import com.gamegoo.repository.chat.MemberChatroomRepository;
 import com.gamegoo.repository.friend.FriendRepository;
 import com.gamegoo.repository.friend.FriendRequestsRepository;
@@ -34,6 +35,7 @@ public class ProfileService {
     private final FriendRepository friendRepository;
     private final FriendRequestsRepository friendRequestsRepository;
     private final MemberChatroomRepository memberChatroomRepository;
+    private final BoardRepository boardRepository;
     private final AuthService authService;
 
     /**
@@ -117,6 +119,9 @@ public class ProfileService {
             member, FriendRequestStatus.PENDING);
         receivedFriendRequestsList.forEach(
             friendRequests -> friendRequests.updateStatus(FriendRequestStatus.CANCELLED));
+
+        // 게시판 글 삭제 처리 (deleted = true)
+        boardRepository.deleteByMemberId(member.getId());
 
         // refresh token 삭제하기
         authService.deleteRefreshToken(userId);


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
게시판 도메인 회원 탈퇴 관련 로직 추가

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- board 테이블에 deleted 컬럼 생성 (default : false)
- 회원 탈퇴 시 해당 회원의 게시판 글 삭제 처리 (soft delete 방식)

## ⏳ 작업 내용
- [x] 게시판 글 목록 조회 API - 회원 탈퇴 시 해당 회원의 게시판 글 삭제 처리, 조회 불가
- [x] 회원용 게시판 글 조회 API - 회원 탈퇴 시 해당 회원의 게시판 글 삭제 처리, 조회 불가
- [x] 비회원용 게시판 글 조회 API - 회원 탈퇴 시 해당 회원의 게시판 글 삭제 처리, 조회 불가

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
