### PR TITLE
[Fix/246] 매너/비매너 평가 수정 시 isExist 값 업데이트

### DIFF
--- a/src/main/java/com/gamegoo/service/manner/MannerService.java
+++ b/src/main/java/com/gamegoo/service/manner/MannerService.java
@@ -566,6 +566,10 @@ public class MannerService {
 
             MannerRating negativeMannerRating = negativeMannerRatings.get(0);
 
+            if (negativeMannerRating.getMannerRatingKeywordList().isEmpty()){
+                isExist = false;
+            }
+
             List<Long> badMannerKeywordIds = negativeMannerRating.getMannerRatingKeywordList()
                 .stream()
                 .map(mannerRatingKeyword -> mannerRatingKeyword.getMannerKeyword().getId())

--- a/src/main/java/com/gamegoo/service/manner/MannerService.java
+++ b/src/main/java/com/gamegoo/service/manner/MannerService.java
@@ -512,6 +512,10 @@ public class MannerService {
 
             MannerRating positiveMannerRating = positiveMannerRatings.get(0);
 
+            if (positiveMannerRating.getMannerRatingKeywordList().isEmpty()){
+                isExist = false;
+            }
+
             List<Long> mannerKeywordIds = positiveMannerRating.getMannerRatingKeywordList().stream()
                 .map(mannerRatingKeyword -> mannerRatingKeyword.getMannerKeyword().getId())
                 .collect(Collectors.toList());


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
매너/비매너 평가 수정 후, 모든 값이 상쇄된 경우 ("mannerRatingKeywordList" 이 빈 배열이 될 경우) isExist 값이 제대로 반영되지 않는 문제 발생.
(매너평가를 '캐리했어요'선택하여 하고, 매너평가 수정으로 '캐리했어요' 체크를 해제)

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 매너평가 수정 시 모든 값이 상쇄될 경우 isExist 값 false로 업데이트
- 비매너평가 수정 시 모든 값이 상쇄될 경우 isExist 값 false로 업데이트

## ⏳ 작업 내용
- [x] 매너평가 조회 API - 매너평가 수정 시 모든 값이 상쇄될 경우 isExist 값 false로 업데이트
- [x] 비매너평가 조회 API - 비매너평가 수정 시 모든 값이 상쇄될 경우 isExist 값 false로 업데이트

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
