### PR TITLE
[Fix/249] 매너/비매너 평가 수정 시 모든 값이 상쇄될 경우의 로직 변경

### DIFF
--- a/src/main/java/com/gamegoo/service/manner/MannerService.java
+++ b/src/main/java/com/gamegoo/service/manner/MannerService.java
@@ -512,10 +512,6 @@ public class MannerService {
 
             MannerRating positiveMannerRating = positiveMannerRatings.get(0);
 
-            if (positiveMannerRating.getMannerRatingKeywordList().isEmpty()){
-                isExist = false;
-            }
-
             List<Long> mannerKeywordIds = positiveMannerRating.getMannerRatingKeywordList().stream()
                 .map(mannerRatingKeyword -> mannerRatingKeyword.getMannerKeyword().getId())
                 .collect(Collectors.toList());
@@ -565,10 +561,6 @@ public class MannerService {
             isExist = true;
 
             MannerRating negativeMannerRating = negativeMannerRatings.get(0);
-
-            if (negativeMannerRating.getMannerRatingKeywordList().isEmpty()){
-                isExist = false;
-            }
 
             List<Long> badMannerKeywordIds = negativeMannerRating.getMannerRatingKeywordList()
                 .stream()


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
매너/비매너 평가 수정 시 모든 값이 상쇄될 경우의 로직 변경

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 매너/비매너 평가 수정 -> 매너/비매너 평가 체크가 모두 해제 -> 선택항목이 0개가 되었을 때
"(응답값) isExist : true , 등록하기 불가, 수정하기만 가능" 로 로직을 변경.

## ⏳ 작업 내용
- [x] 매너/비매너 평가 수정 시 모든 값이 상쇄될 경우의 로직 변경

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
