### PR TITLE
[Feat/247] 매너 평가 도메인 회원 탈퇴 관련 로직 추가

### DIFF
--- a/src/main/java/com/gamegoo/repository/manner/MannerRatingRepository.java
+++ b/src/main/java/com/gamegoo/repository/manner/MannerRatingRepository.java
@@ -2,13 +2,18 @@ package com.gamegoo.repository.manner;
 
 import com.gamegoo.domain.manner.MannerRating;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 public interface MannerRatingRepository extends JpaRepository<MannerRating, Long> {
     List<MannerRating> findByToMemberId(Long toMember);
     List<MannerRating> findByFromMemberIdAndToMemberId(Long fromMember, Long toMember);
+    List<MannerRating> findByFromMemberId(Long memberId);
 
+    @Query("DELETE FROM MannerRating mr WHERE mr.fromMember.id = :memberId")
+    void deleteByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/gamegoo/service/manner/MannerService.java
+++ b/src/main/java/com/gamegoo/service/manner/MannerService.java
@@ -441,6 +441,18 @@ public class MannerService {
             member.setMannerScore(mannerScore);
             // 매너레벨 결정.
             Integer mannerLevel = mannerLevel(mannerScore);
+            // 매너레벨 상승 알림 전송
+            if (member.getMannerLevel() < mannerLevel) {
+                Notification mannerUpNotification = notificationService.createNotification(
+                        NotificationTypeTitle.MANNER_LEVEL_UP, mannerLevel.toString(),
+                        null, member);
+                notificationRepository.save(mannerUpNotification);
+            } else if (member.getMannerLevel() > mannerLevel) { // 매너레벨 하락 알림 전송
+                Notification mannerDownNotification = notificationService.createNotification(
+                        NotificationTypeTitle.MANNER_LEVEL_DOWN, mannerLevel.toString(),
+                        null, member);
+                notificationRepository.save(mannerDownNotification);
+            }
             // 매너레벨 반영.
             member.setMannerLevel(mannerLevel);
             // db 저장.

--- a/src/main/java/com/gamegoo/service/manner/MannerService.java
+++ b/src/main/java/com/gamegoo/service/manner/MannerService.java
@@ -419,6 +419,35 @@ public class MannerService {
         }
     }
 
+    //매너,비매너 평가 기록 삭제 처리
+    @Transactional
+    public void deleteMannerRatingsByMemberId(Long memberId) {
+        // 탈퇴한 회원이 남긴 매너,비매너 평가 기록
+        List<MannerRating> mannerRatings = mannerRatingRepository.findByFromMemberId(memberId);
+
+        // 탈퇴한 회원으로부터 매너,비매너 평가를 받은 회원 목록
+        List<Member> toMembers = mannerRatings.stream()
+                .map(MannerRating::getToMember)
+                .distinct()  // 중복된 회원 제거
+                .collect(Collectors.toList());
+
+        // 탈퇴한 회원이 남긴 매너.비매너 평가 삭제
+        mannerRatingRepository.deleteByMemberId(memberId);
+
+        for (Member member : toMembers){
+            // 매너점수 산정.
+            Integer mannerScore = updateMannerScore(member);
+            // 매너점수 반영.
+            member.setMannerScore(mannerScore);
+            // 매너레벨 결정.
+            Integer mannerLevel = mannerLevel(mannerScore);
+            // 매너레벨 반영.
+            member.setMannerLevel(mannerLevel);
+            // db 저장.
+            memberRepository.save(member);
+        }
+    }
+
     // 매너점수를 산정하고 업데이트.
     private int updateMannerScore(Member targetMember) {
 
@@ -427,8 +456,10 @@ public class MannerService {
 
         int totalCount = 0;
 
-        // 매너 평가 + 비매너 평가를 처음 받은 회원
-        if (mannerRatings.size() == 1) {
+        // 내게 평가를 남긴 회원이 모두 탈퇴하여 매너,비매너 평가 이력이 없어진 경우
+        if (mannerRatings.size() == 0) {
+            totalCount = 0;
+        } else if (mannerRatings.size() == 1) {  // 매너 평가 + 비매너 평가를 처음 받은 회원
             if (mannerRatings.get(0).getIsPositive()) {
                 totalCount = mannerRatings.get(0).getMannerRatingKeywordList().size();
             } else {

--- a/src/main/java/com/gamegoo/service/member/ProfileService.java
+++ b/src/main/java/com/gamegoo/service/member/ProfileService.java
@@ -21,6 +21,8 @@ import com.gamegoo.repository.member.MemberRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import com.gamegoo.service.manner.MannerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,6 +38,7 @@ public class ProfileService {
     private final FriendRequestsRepository friendRequestsRepository;
     private final MemberChatroomRepository memberChatroomRepository;
     private final BoardRepository boardRepository;
+    private final MannerService mannerService;
     private final AuthService authService;
 
     /**
@@ -122,6 +125,9 @@ public class ProfileService {
 
         // 게시판 글 삭제 처리 (deleted = true)
         boardRepository.deleteByMemberId(member.getId());
+
+        // 매너,비매너 평가 기록 삭제 처리
+        mannerService.deleteMannerRatingsByMemberId(member.getId());
 
         // refresh token 삭제하기
         authService.deleteRefreshToken(userId);

--- a/src/main/java/com/gamegoo/service/notification/NotificationService.java
+++ b/src/main/java/com/gamegoo/service/notification/NotificationService.java
@@ -2,15 +2,16 @@ package com.gamegoo.service.notification;
 
 
 import com.gamegoo.apiPayload.code.status.ErrorStatus;
+import com.gamegoo.apiPayload.exception.handler.MemberHandler;
 import com.gamegoo.apiPayload.exception.handler.NotificationHandler;
 import com.gamegoo.apiPayload.exception.handler.PageHandler;
 import com.gamegoo.domain.member.Member;
 import com.gamegoo.domain.notification.Notification;
 import com.gamegoo.domain.notification.NotificationType;
 import com.gamegoo.domain.notification.NotificationTypeTitle;
+import com.gamegoo.repository.member.MemberRepository;
 import com.gamegoo.repository.notification.NotificationRepository;
 import com.gamegoo.repository.notification.NotificationTypeRepository;
-import com.gamegoo.service.member.ProfileService;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -27,7 +28,7 @@ public class NotificationService {
 
     private final NotificationTypeRepository notificationTypeRepository;
     private final NotificationRepository notificationRepository;
-    private final ProfileService profileService;
+    private final MemberRepository memberRepository;
 
     private static final int PAGE_SIZE = 10;
 
@@ -98,7 +99,8 @@ public class NotificationService {
      * @return
      */
     public Slice<Notification> getNotificationListByCursor(Long memberId, Long cursor) {
-        Member member = profileService.findMember(memberId);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         return notificationRepository.findNotificationsByCursor(member.getId(),
             cursor);
@@ -113,7 +115,8 @@ public class NotificationService {
      */
     public Page<Notification> getNotificationListByPage(Long memberId,
         Integer pageIdx) {
-        Member member = profileService.findMember(memberId);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         if (pageIdx < 0) {
             throw new PageHandler(ErrorStatus.PAGE_INVALID);
@@ -133,7 +136,8 @@ public class NotificationService {
      * @return
      */
     public Notification readNotification(Long memberId, Long notificationId) {
-        Member member = profileService.findMember(memberId);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         // 알림 엔티티 조회 및 검증
         Notification notification = notificationRepository.findById(notificationId)
@@ -156,7 +160,8 @@ public class NotificationService {
      * @return
      */
     public long countUnreadNotification(Long memberId) {
-        Member member = profileService.findMember(memberId);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         return member.getNotificationList().stream()
             .filter(notification -> !notification.isRead())


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
매너 평가 도메인 회원 탈퇴 관련 로직 추가

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- NotificationService 코드 리팩토링
- 탈퇴한 사용자가 상대방에게 남긴 모든 매너/비매너 평가 및 점수 삭제 처리 
- 탈퇴한 회원으로부터 매너평가를 받은 이력이 있는 회원들의 변동 점수에 따른 알람기능 추가

## ⏳ 작업 내용
- [x] NotificationService 코드 리팩토링 (profileService 참조x , repository에서 직접 조회)
- [x] 탈퇴한 사용자가 상대방에게 남긴 모든 매너/비매너 평가 및 점수 삭제 처리 (hard delete)
- [x] 탈퇴한 회원으로부터 매너평가를 받은 이력이 있는 회원들의 변동 점수에 따른 알람기능 추가

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- repository에서 직접 조회로 NotificationService 코드를 리팩토링 했는데, 나중에 설계를 변경해야 할 수도 있을 것 같습니다.
- 상대방에게 남긴 모든 매너/비매너 평가 이력을 hard delete 로 구현했는데, 추후 변경될 수도 있을 것 같습니다.