### PR TITLE
[Fix/262] Auth & Profile 관련 에러 수정

### DIFF
--- a/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/gamegoo/apiPayload/code/status/ErrorStatus.java
@@ -46,6 +46,7 @@ public enum ErrorStatus implements BaseErrorCode {
     EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "EMAIL401", "해당 이메일을 찾을 수 없습니다."),
     EMAIL_INVALID_CODE(HttpStatus.BAD_REQUEST, "EMAIL402", "인증 코드가 불일치합니다."),
     EMAIL_INVALID_TIME(HttpStatus.BAD_REQUEST, "EMAIL403", "이메일 인증 시간이 3분 초과했습니다."),
+    EMAIL_INVALID_USER(HttpStatus.BAD_REQUEST,"EMAIL404","DB에 없는 이메일을 요청했습니다."),
 
     // 매칭 관련 에러
     MATCHING_STATUS_BAD_REQUEST(HttpStatus.BAD_REQUEST, "MATCH400",

--- a/src/main/java/com/gamegoo/controller/member/AuthController.java
+++ b/src/main/java/com/gamegoo/controller/member/AuthController.java
@@ -44,7 +44,9 @@ public class AuthController {
     public ApiResponse<String> sendEmailwithCheckDuplication(
             @Valid @RequestBody MemberRequest.EmailRequestDTO emailRequestDTO) {
         String email = emailRequestDTO.getEmail();
-        authService.sendEmail(email, true);
+
+        authService.verifyEmail(email);
+        authService.sendEmail(email);
         return ApiResponse.onSuccess("인증 이메일을 발송했습니다.");
     }
 
@@ -53,7 +55,20 @@ public class AuthController {
     public ApiResponse<String> sendEmail(
             @Valid @RequestBody MemberRequest.EmailRequestDTO emailRequestDTO) {
         String email = emailRequestDTO.getEmail();
-        authService.sendEmail(email, false);
+        authService.sendEmail(email);
+        return ApiResponse.onSuccess("인증 이메일을 발송했습니다.");
+    }
+
+    @PostMapping("/email/send/user")
+    @Operation(summary = "이메일 인증코드 전송 API 입니다. 겜구 회원 조회 전용", description = "API for sending email")
+    public ApiResponse<String> sendEmailforUser(
+            @Valid @RequestBody MemberRequest.EmailRequestDTO emailRequestDTO) {
+        String email = emailRequestDTO.getEmail();
+
+        // DB에 없는 사용자일 경우 에러 발생
+        authService.verifyEmail(email);
+
+        authService.sendEmail(email);
         return ApiResponse.onSuccess("인증 이메일을 발송했습니다.");
     }
 

--- a/src/main/java/com/gamegoo/controller/member/AuthController.java
+++ b/src/main/java/com/gamegoo/controller/member/AuthController.java
@@ -60,7 +60,7 @@ public class AuthController {
     }
 
     @PostMapping("/email/send/user")
-    @Operation(summary = "이메일 인증코드 전송 API 입니다. 겜구 회원 조회 전용", description = "API for sending email")
+    @Operation(summary = "이메일 인증코드 전송 API 입니다. 겜구 회원 조회 전용", description = "API for sending email for exisiting user")
     public ApiResponse<String> sendEmailforUser(
             @Valid @RequestBody MemberRequest.EmailRequestDTO emailRequestDTO) {
         String email = emailRequestDTO.getEmail();

--- a/src/main/java/com/gamegoo/controller/member/ProfileController.java
+++ b/src/main/java/com/gamegoo/controller/member/ProfileController.java
@@ -75,6 +75,18 @@ public class ProfileController {
         return ApiResponse.onSuccess("프로필 이미지 수정이 완료되었습니다.");
     }
 
+    @PutMapping("/mike")
+    @Operation(summary = "마이크 여부 수정 API 입니다.", description = "API for Mike Modification")
+    public ApiResponse<String> modifyMike(
+        @Valid @RequestBody MemberRequest.MikeRequestDTO mikeRequestDTO) {
+        Long userId = JWTUtil.getCurrentUserId();
+        Boolean isMike = mikeRequestDTO.getIsMike();
+
+        profileService.modifyMike(userId, isMike);
+
+        return ApiResponse.onSuccess("마이크 여부 수정이 완료되었습니다.");
+    }
+
     @DeleteMapping("")
     @Operation(summary = "회원 탈퇴 API 입니다.", description = "API for Blinding Member")
     public ApiResponse<String> blindMember() {

--- a/src/main/java/com/gamegoo/domain/common/BaseDateTimeEntity.java
+++ b/src/main/java/com/gamegoo/domain/common/BaseDateTimeEntity.java
@@ -1,6 +1,7 @@
 package com.gamegoo.domain.common;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -19,6 +20,8 @@ public abstract class BaseDateTimeEntity {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
+    @Setter
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
 }

--- a/src/main/java/com/gamegoo/domain/member/Member.java
+++ b/src/main/java/com/gamegoo/domain/member/Member.java
@@ -12,6 +12,7 @@ import com.gamegoo.domain.report.Report;
 import lombok.*;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -108,6 +109,12 @@ public class Member extends BaseDateTimeEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<MemberChatroom> memberChatroomList = new ArrayList<>();
+
+    public void updateUpdatedAt() {
+        // 현재 시간을 updatedAt으로 설정
+        this.setUpdatedAt(LocalDateTime.now());
+    }
+
 
     public void updatePosition(Integer mainPosition, Integer subPosition) {
         this.mainPosition = mainPosition;

--- a/src/main/java/com/gamegoo/domain/member/Member.java
+++ b/src/main/java/com/gamegoo/domain/member/Member.java
@@ -115,6 +115,9 @@ public class Member extends BaseDateTimeEntity {
         this.setUpdatedAt(LocalDateTime.now());
     }
 
+    public void updateMike(Boolean isMike){
+        this.mike=isMike;
+    }
 
     public void updatePosition(Integer mainPosition, Integer subPosition) {
         this.mainPosition = mainPosition;

--- a/src/main/java/com/gamegoo/dto/member/MemberRequest.java
+++ b/src/main/java/com/gamegoo/dto/member/MemberRequest.java
@@ -90,6 +90,12 @@ public class MemberRequest {
     }
 
     @Getter
+    public static class MikeRequestDTO {
+        @NotNull(message = "isMike 값은 비워둘 수 없습니다.")
+        Boolean isMike;
+    }
+
+    @Getter
     public static class RefreshTokenRequestDTO {
         @NotBlank(message = "refreshToken 값은 비워둘 수 없습니다.")
         String refreshToken;

--- a/src/main/java/com/gamegoo/dto/member/MemberResponse.java
+++ b/src/main/java/com/gamegoo/dto/member/MemberResponse.java
@@ -47,6 +47,7 @@ public class MemberResponse {
         String refreshToken;
         String name;
         Integer profileImage;
+        Long memberId;
 
     }
 

--- a/src/main/java/com/gamegoo/dto/member/MemberResponse.java
+++ b/src/main/java/com/gamegoo/dto/member/MemberResponse.java
@@ -42,12 +42,12 @@ public class MemberResponse {
     @Setter
     @AllArgsConstructor
     public static class LoginResponseDTO {
-
+        Long id;
         String accessToken;
         String refreshToken;
         String name;
         Integer profileImage;
-        Long memberId;
+
 
     }
 
@@ -75,7 +75,7 @@ public class MemberResponse {
     @Setter
     @AllArgsConstructor
     public static class RefreshTokenResponseDTO {
-
+        Long id;
         String accessToken;
         String refreshToken;
     }

--- a/src/main/java/com/gamegoo/filter/LoginFilter.java
+++ b/src/main/java/com/gamegoo/filter/LoginFilter.java
@@ -83,7 +83,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         // Response body에 넣기
         MemberResponse.LoginResponseDTO loginResponseDTO = new MemberResponse.LoginResponseDTO(
-                access_token, refresh_token, gameuserName, profileImage, member.getId());
+                member.getId(), access_token, refresh_token, gameuserName, profileImage);
 
         // 헤더에 추가
         response.addHeader("Authorization", "Bearer " + access_token);

--- a/src/main/java/com/gamegoo/filter/LoginFilter.java
+++ b/src/main/java/com/gamegoo/filter/LoginFilter.java
@@ -83,7 +83,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         // Response body에 넣기
         MemberResponse.LoginResponseDTO loginResponseDTO = new MemberResponse.LoginResponseDTO(
-                access_token, refresh_token, gameuserName, profileImage);
+                access_token, refresh_token, gameuserName, profileImage, member.getId());
 
         // 헤더에 추가
         response.addHeader("Authorization", "Bearer " + access_token);

--- a/src/main/java/com/gamegoo/service/member/AuthService.java
+++ b/src/main/java/com/gamegoo/service/member/AuthService.java
@@ -128,17 +128,30 @@ public class AuthService {
     }
 
     /**
+     * 이메일 중복 확인 검증
+     * @param email
+     */
+    public void verifyEmail(String email){
+        // 해당 이메일이 DB에 있는지 확인하기
+        boolean isPresent = memberRepository.findByEmail(email).isPresent();
+
+        if (isPresent) {
+            // 중복확인 (회원가입 전용)
+            throw new MemberHandler(ErrorStatus.MEMBER_CONFLICT);
+        }else{
+            // DB에 없는 사용자인지 확인 (비밀번호 찾기 전용)
+            throw new MemberHandler(ErrorStatus.EMAIL_INVALID_USER);
+        }
+
+    }
+
+    /**
      * 이메일 인증코드 발송 & 이메일 전송 기록 저장
      *
      * @param email
      */
     @Transactional
-    public void sendEmail(String email, Boolean isCheck) {
-        // 중복 확인하기
-        boolean isPresent = memberRepository.findByEmail(email).isPresent();
-        if (isPresent && isCheck) {
-            throw new MemberHandler(ErrorStatus.MEMBER_CONFLICT);
-        }
+    public void sendEmail(String email) {
 
         // 랜덤 코드 생성하기
         String certificationNumber = CodeGeneratorUtil.generateRandomCode();
@@ -245,144 +258,141 @@ public class AuthService {
      */
     private String getCertificationMessage(String certificationNumber) {
         String certificationMessage = ""
-                + "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">"
-                + "<html xmlns=\"http://www.w3.org/1999/xhtml\">"
-                + "  <head>"
-                + "    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />"
-                + "    <title>Gamegoo 이메일 인증</title>"
-                + "    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" />"
-                + "  </head>"
-                + "  <body>"
-                + "    <table"
-                + "      style=\""
-                + "        width: 628px;"
-                + "        box-sizing: border-box;"
-                + "        border-collapse: collapse;"
-                + "        background-color: #ffffff;"
-                + "        border: 1px solid #c0c0c0;"
-                + "        text-align: left;"
-                + "        margin: 0 auto;"
-                + "      \""
-                + "    >"
-                + "      <tbody>"
-                + "        <tr>"
-                + "          <td>"
-                + "            <table"
-                + "              cellpadding=\"0\""
-                + "              cellspacing=\"0\""
-                + "              style=\"width: 628px; height: 521px; padding: 53px 42px 42px 62px\""
-                + "            >"
-                + "              <tbody>"
-                + "                <tr>"
-                + "                  <td style=\"padding-bottom: 11.61px\">"
-                + "                    <img"
-                + "                      src=\"https://ifh.cc/g/BY3XG2.png\""
-                + "                      style=\"display: block\""
-                + "                      width=\"137\""
-                + "                      height=\"24\""
-                + "                      alt=\"Gamegoo\""
-                + "                    />"
-                + "                  </td>"
-                + "                </tr>"
-                + "                <tr>"
-                + "                  <td style=\"padding-top: 20px\">"
-                + "                    <span"
-                + "                      style=\""
-                + "                        color: #2d2d2d;"
-                + "                        font-family: Pretendard;"
-                + "                        font-size: 25px;"
-                + "                        font-style: normal;"
-                + "                        font-weight: 400;"
-                + "                        line-height: 150%;"
-                + "                      \""
-                + "                    >"
-                + "                      인증코드를 확인해주세요"
-                + "                    </span>"
-                + "                  </td>"
-                + "                </tr>"
-                + "                <tr>"
-                + "                  <td style=\"padding-top: 38px\">"
-                + "                    <span"
-                + "                      style=\""
-                + "                        color: #5a42ee;"
-                + "                        color: #2d2d2d;"
-                + "                        font-size: 32px;"
-                + "                        font-style: normal;"
-                + "                        font-weight: 700;"
-                + "                        line-height: 150%;"
-                + "                        margin-bottom: 30px;"
-                + "                      \""
-                + "                    >"
-                + "                      " + certificationNumber + ""
-                + "                    </span>"
-                + "                  </td>"
-                + "                </tr>"
-                + "                <tr>"
-                + "                  <td style=\"padding-top: 30px\">"
-                + "                    <span"
-                + "                      style=\""
-                + "                        color: #2d2d2d;"
-                + "                        font-family: Pretendard;"
-                + "                        font-size: 18px;"
-                + "                        font-style: normal;"
-                + "                        font-weight: 400;"
-                + "                        line-height: 150%;"
-                + "                      \""
-                + "                    >"
-                + "                      이메일 인증 절차에 따라 이메일 인증코드를"
-                + "                      발급해드립니다.<br />"
-                + "                      인증코드는 이메일 발송시점으로부터 3분 동안 유효합니다.<br /><br />"
-                + "                      만약 본인 요청에 의한 이메일 인증이 아니라면,"
-                + "                      고객센터(0000-0000) 또는 cs@gamegoo.com으로 관련 내용을"
-                + "                      전달해 주세요.<br /><br />"
-                + "                      감사합니다."
-                + "                    </span>"
-                + "                  </td>"
-                + "                </tr>"
-                + "              </tbody>"
-                + "            </table>"
-                + "            <table"
-                + "              cellpadding=\"0\""
-                + "              cellspacing=\"0\""
-                + "              style=\""
-                + "                width: 628px;"
-                + "                height: 292px;"
-                + "                padding: 37px 0px 51px 62px;"
-                + "                background: #f7f7f9;"
-                + "              \""
-                + "            >"
-                + "              <tbody>"
-                + "                <tr>"
-                + "                  <td>"
-                + "                    <span"
-                + "                      style=\""
-                + "                        color: #606060;"
-                + "                        font-family: Pretendard;"
-                + "                        font-size: 11px;"
-                + "                        font-style: normal;"
-                + "                        font-weight: 500;"
-                + "                        line-height: 150%;"
-                + "                      \""
-                + "                    >"
-                + "                      본 메일은 발신 전용으로 회신되지 않습니다.<br />"
-                + "                      궁금하신 점은 겜구 고객센터를 통해 문의하시기 바랍니다.<br /><br />"
-                + "                      Email: gamegoo0707@gmail.com<br /><br />"
-                + "                      06236 서울특별시 강남구 테헤란로20길5, 8층 겜구<br />"
-                + "                      대표이사 : 김예림 | 개인정보보호책임자 : 김예림<br />"
-                + "                      사업자 등록번호 [842-86-00373]<br />"
-                + "                      통신판매업 신고 : 제 2017-서울강남-00718호<br /><br /><br />"
-                + "                      © 겜구(주) All rights reserved. gamegoo.co.kr"
-                + "                    </span>"
-                + "                  </td>"
-                + "                </tr>"
-                + "              </tbody>"
-                + "            </table>"
-                + "          </td>"
-                + "        </tr>"
-                + "      </tbody>"
-                + "    </table>"
-                + "  </body>"
-                + "</html>";
+                +"<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n" +
+                "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n" +
+                "  <head>\n" +
+                "    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\n" +
+                "    <title>Gamegoo 이메일 인증</title>\n" +
+                "    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" />\n" +
+                "  </head>\n" +
+                "  <body>\n" +
+                "    <table\n" +
+                "      style=\"\n" +
+                "        width: 628px;\n" +
+                "        box-sizing: border-box;\n" +
+                "        border-collapse: collapse;\n" +
+                "        background-color: #ffffff;\n" +
+                "        border: 1px solid #c0c0c0;\n" +
+                "        text-align: left;\n" +
+                "        margin: 0 auto;\n" +
+                "      \"\n" +
+                "    >\n" +
+                "      <tbody>\n" +
+                "        <tr>\n" +
+                "          <td>\n" +
+                "            <table\n" +
+                "              cellpadding=\"0\"\n" +
+                "              cellspacing=\"0\"\n" +
+                "              style=\"width: 628px; height: 521px; padding: 53px 62px 42px 62px\"\n" +
+                "            >\n" +
+                "              <tbody>\n" +
+                "                <tr>\n" +
+                "                  <td style=\"padding-bottom: 11.61px\">\n" +
+                "                    <img\n" +
+                "                      src=\"https://ifh.cc/g/BY3XG2.png\"\n" +
+                "                      style=\"display: block\"\n" +
+                "                      width=\"137\"\n" +
+                "                      height=\"24\"\n" +
+                "                      alt=\"Gamegoo\"\n" +
+                "                    />\n" +
+                "                  </td>\n" +
+                "                </tr>\n" +
+                "                <tr>\n" +
+                "                  <td style=\"padding-top: 20px\">\n" +
+                "                    <span\n" +
+                "                      style=\"\n" +
+                "                        color: #2d2d2d;\n" +
+                "                        font-family: Pretendard;\n" +
+                "                        font-size: 25px;\n" +
+                "                        font-style: normal;\n" +
+                "                        font-weight: 400;\n" +
+                "                        line-height: 150%;\n" +
+                "                      \"\n" +
+                "                    >\n" +
+                "                      인증코드를 확인해주세요\n" +
+                "                    </span>\n" +
+                "                  </td>\n" +
+                "                </tr>\n" +
+                "                <tr>\n" +
+                "                  <td style=\"padding-top: 38px\">\n" +
+                "                    <span\n" +
+                "                      style=\"\n" +
+                "                        color: #5a42ee;\n" +
+                "                        color: #2d2d2d;\n" +
+                "                        font-size: 32px;\n" +
+                "                        font-style: normal;\n" +
+                "                        font-weight: 700;\n" +
+                "                        line-height: 150%;\n" +
+                "                        margin-bottom: 30px;\n" +
+                "                      \"\n" +
+                "                    >\n" +
+                                      certificationNumber+
+                "                    </span>\n" +
+                "                  </td>\n" +
+                "                </tr>\n" +
+                "                <tr>\n" +
+                "                  <td style=\"padding-top: 30px\">\n" +
+                "                    <span\n" +
+                "                      style=\"\n" +
+                "                        color: #2d2d2d;\n" +
+                "                        font-family: Pretendard;\n" +
+                "                        font-size: 18px;\n" +
+                "                        font-style: normal;\n" +
+                "                        font-weight: 400;\n" +
+                "                        line-height: 150%;\n" +
+                "                      \"\n" +
+                "                    >\n" +
+                "                      이메일 인증 절차에 따라 이메일 인증코드를 발급해드립니다.\n" +
+                "                      인증코드는 이메일 발송시점으로부터 3분 동안 유효합니다.<br /><br />\n" +
+                "                      만약 본인 요청에 의한 이메일 인증이 아니라면,<br />\n" +
+                "                      gamegoo0707@gmail.com으로 관련 내용을 전달해 주세요.<br /><br />\n" +
+                "\n" +
+                "                      감사합니다.\n" +
+                "                    </span>\n" +
+                "                  </td>\n" +
+                "                </tr>\n" +
+                "              </tbody>\n" +
+                "            </table>\n" +
+                "            <table\n" +
+                "              cellpadding=\"0\"\n" +
+                "              cellspacing=\"0\"\n" +
+                "              style=\"\n" +
+                "                width: 628px;\n" +
+                "                height: 292px;\n" +
+                "                padding: 37px 0px 153px 62px;\n" +
+                "                background: #f7f7f9;\n" +
+                "              \"\n" +
+                "            >\n" +
+                "              <tbody>\n" +
+                "                <tr>\n" +
+                "                  <td>\n" +
+                "                    <span\n" +
+                "                      style=\"\n" +
+                "                        color: #606060;\n" +
+                "                        font-family: Pretendard;\n" +
+                "                        font-size: 11px;\n" +
+                "                        font-style: normal;\n" +
+                "                        font-weight: 500;\n" +
+                "                        line-height: 150%;\n" +
+                "                      \"\n" +
+                "                    >\n" +
+                "                      본 메일은 발신 전용으로 회신되지 않습니다.<br />\n" +
+                "                      궁금하신 점은 겜구 이메일이나 카카오 채널을 통해\n" +
+                "                      문의하시기 바랍니다.<br /><br />\n" +
+                "                      email: gamegoo0707@gmail.com<br />\n" +
+                "                      kakao: https://pf.kakao.com/_Rrxiqn<br />\n" +
+                "                      copyright 2024. GameGoo All Rights Reserved.<br />\n" +
+                "                    </span>\n" +
+                "                  </td>\n" +
+                "                </tr>\n" +
+                "              </tbody>\n" +
+                "            </table>\n" +
+                "          </td>\n" +
+                "        </tr>\n" +
+                "      </tbody>\n" +
+                "    </table>\n" +
+                "  </body>\n" +
+                "</html>\n";
 
         return certificationMessage;
     }

--- a/src/main/java/com/gamegoo/service/member/AuthService.java
+++ b/src/main/java/com/gamegoo/service/member/AuthService.java
@@ -178,7 +178,7 @@ public class AuthService {
         member.updateRefreshToken(new_refresh_token);
         memberRepository.save(member);
 
-        return new MemberResponse.RefreshTokenResponseDTO(access_token, new_refresh_token);
+        return new MemberResponse.RefreshTokenResponseDTO(id,access_token, new_refresh_token);
     }
 
     /**

--- a/src/main/java/com/gamegoo/service/member/ProfileService.java
+++ b/src/main/java/com/gamegoo/service/member/ProfileService.java
@@ -88,6 +88,8 @@ public class ProfileService {
             }
         }
 
+        member.updateUpdatedAt();
+        memberRepository.save(member);
         return member.getMemberGameStyleList();
     }
 

--- a/src/main/java/com/gamegoo/service/member/ProfileService.java
+++ b/src/main/java/com/gamegoo/service/member/ProfileService.java
@@ -174,6 +174,22 @@ public class ProfileService {
     }
 
     /**
+     * 프로필 이미지 수정
+     *
+     * @param userId
+     * @param isMike
+     */
+    @Transactional
+    public void modifyMike(Long userId, Boolean isMike) {
+        Member member = memberRepository.findById(userId)
+            .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        member.updateMike(isMike);
+
+        memberRepository.save(member);
+    }
+
+    /**
      * 회원 정보 조회
      *
      * @param memberId


### PR DESCRIPTION
## 🚀 개요
QA 반영 Auth & Profile 관련 에러 수정

## 🔍 변경사항
- 겜구 사용자 전용 이메일 인증 API 추가
- 마이크 여부 수정 API 추가
- updatedAt 수동으로 업데이트하는 코드 추가
- login DTO에 memberId 추가

## ⏳ 작업 내용
- [x] login 할 때 response dto에 memberId 추가
- [x] refresh 토큰 발급할 때 response dto에 memberId 추가
- [x] 겜구 사용자 전용 이메일 인증 API 추가 (DB에 있는 사용자일 경우에만 이메일 인증)
- [x] 게임스타일이 변경됐을 경우 updatedAt도 함께 변경

### 📝 논의사항
