### PR TITLE
[Fix/281] 게시판 글 작성,수정 시 게임모드 칼바람일때 포지션 null 값 허용

### DIFF
--- a/src/main/java/com/gamegoo/domain/board/Board.java
+++ b/src/main/java/com/gamegoo/domain/board/Board.java
@@ -24,13 +24,13 @@ public class Board extends BaseDateTimeEntity {
     @Column(name = "mode", nullable = false)
     private Integer mode;
 
-    @Column(name = "main_position", nullable = false)
+    @Column(name = "main_position")
     private Integer mainPosition;
 
-    @Column(name = "sub_position", nullable = false)
+    @Column(name = "sub_position")
     private Integer subPosition;
 
-    @Column(name = "want_position", nullable = false)
+    @Column(name = "want_position")
     private Integer wantPosition;
 
     @Column(name = "mike")

--- a/src/main/java/com/gamegoo/dto/board/BoardRequest.java
+++ b/src/main/java/com/gamegoo/dto/board/BoardRequest.java
@@ -17,13 +17,10 @@ public class BoardRequest {
         @NotNull
         Integer gameMode;
 
-        @NotNull
         Integer mainPosition;
 
-        @NotNull
         Integer subPosition;
 
-        @NotNull
         Integer wantPosition;
 
         @Schema(description = "마이크 사용 여부", defaultValue = "false")

--- a/src/main/java/com/gamegoo/service/board/BoardService.java
+++ b/src/main/java/com/gamegoo/service/board/BoardService.java
@@ -60,19 +60,41 @@ public class BoardService {
             throw new BoardHandler(ErrorStatus.GAME_MODE_INVALID);
         }
 
+        // 칼바람일때만 포지션 null 값 허용
+
         // 주 포지션 값 검증. (0 ~ 5값만 가능)
-        if (request.getMainPosition() < 0 || request.getMainPosition() > 5) {
-            throw new BoardHandler(ErrorStatus.MAIN_POSITION_INVALID);
+        if (request.getGameMode()==4) {
+            if (request.getMainPosition() != null && (request.getMainPosition() < 0 || request.getMainPosition() > 5)) {
+                throw new BoardHandler(ErrorStatus.MAIN_POSITION_INVALID);
+            }
+        }
+        else {
+            if (request.getMainPosition() == null || request.getMainPosition() < 0 || request.getMainPosition() > 5) {
+                throw new BoardHandler(ErrorStatus.MAIN_POSITION_INVALID);
+            }
         }
 
         // 부 포지션 값 검증. (0 ~ 5값만 가능)
-        if (request.getSubPosition() < 0 || request.getSubPosition() > 5) {
-            throw new BoardHandler(ErrorStatus.SUB_POSITION_INVALID);
+        if (request.getGameMode()==4) {
+            if (request.getSubPosition() != null && (request.getSubPosition() < 0 || request.getSubPosition() > 5)) {
+                throw new BoardHandler(ErrorStatus.SUB_POSITION_INVALID);
+            }
+        }
+        else {
+            if (request.getSubPosition() == null || request.getSubPosition() < 0 || request.getSubPosition() > 5) {
+                throw new BoardHandler(ErrorStatus.SUB_POSITION_INVALID);
+            }
         }
 
         // 상대 포지션 값 검증. (0 ~ 5값만 가능)
-        if (request.getWantPosition() < 0 || request.getWantPosition() > 5) {
-            throw new BoardHandler(ErrorStatus.WANT_POSITION_INVALID);
+        if (request.getGameMode()==4) {
+            if (request.getWantPosition() != null && (request.getWantPosition() < 0 || request.getWantPosition() > 5)) {
+                throw new BoardHandler(ErrorStatus.WANT_POSITION_INVALID);
+            }
+        }else {
+            if (request.getWantPosition() == null || request.getWantPosition() < 0 || request.getWantPosition() > 5) {
+                throw new BoardHandler(ErrorStatus.WANT_POSITION_INVALID);
+            }
         }
 
         // 마이크 설정 (default=false)
@@ -151,19 +173,41 @@ public class BoardService {
             throw new BoardHandler(ErrorStatus.GAME_MODE_INVALID);
         }
 
+        // 칼바람일때만 포지션 null 값 허용
+
         // 주 포지션 값 검증. (0 ~ 5값만 가능)
-        if (request.getMainPosition() < 0 || request.getMainPosition() > 5) {
-            throw new BoardHandler(ErrorStatus.MAIN_POSITION_INVALID);
+        if (request.getGameMode()==4) {
+            if (request.getMainPosition() != null && (request.getMainPosition() < 0 || request.getMainPosition() > 5)) {
+                throw new BoardHandler(ErrorStatus.MAIN_POSITION_INVALID);
+            }
+        }
+        else {
+            if (request.getMainPosition() == null || request.getMainPosition() < 0 || request.getMainPosition() > 5) {
+                throw new BoardHandler(ErrorStatus.MAIN_POSITION_INVALID);
+            }
         }
 
         // 부 포지션 값 검증. (0 ~ 5값만 가능)
-        if (request.getSubPosition() < 0 || request.getSubPosition() > 5) {
-            throw new BoardHandler(ErrorStatus.SUB_POSITION_INVALID);
+        if (request.getGameMode()==4) {
+            if (request.getSubPosition() != null && (request.getSubPosition() < 0 || request.getSubPosition() > 5)) {
+                throw new BoardHandler(ErrorStatus.SUB_POSITION_INVALID);
+            }
+        }
+        else {
+            if (request.getSubPosition() == null || request.getSubPosition() < 0 || request.getSubPosition() > 5) {
+                throw new BoardHandler(ErrorStatus.SUB_POSITION_INVALID);
+            }
         }
 
         // 상대 포지션 값 검증. (0 ~ 5값만 가능)
-        if (request.getWantPosition() < 0 || request.getWantPosition() > 5) {
-            throw new BoardHandler(ErrorStatus.WANT_POSITION_INVALID);
+        if (request.getGameMode()==4) {
+            if (request.getWantPosition() != null && (request.getWantPosition() < 0 || request.getWantPosition() > 5)) {
+                throw new BoardHandler(ErrorStatus.WANT_POSITION_INVALID);
+            }
+        }else {
+            if (request.getWantPosition() == null || request.getWantPosition() < 0 || request.getWantPosition() > 5) {
+                throw new BoardHandler(ErrorStatus.WANT_POSITION_INVALID);
+            }
         }
 
         // 게임 스타일 길이 검증.


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
게시판 글 작성,수정 시 게임모드 칼바람일때 포지션 null 값 허용

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 게시판 글 작성,수정 시 게임모드 칼바람일때 포지션 null 값 허용

## ⏳ 작업 내용
- [x] Board.java 에서 mainPosition, subPosition, wantPosition null 값 허용으로 수정
- [x] 게시판 글 작성 시 게임모드 칼바람일때 포지션 null 값 허용
- [x] 게시판 글 수정 시 게임모드 칼바람일때 포지션 null 값 허용

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
