### PR TITLE
[Fix/286] countUnreadChats 메소드의 lastViewDate 비교 쿼리 수정

### DIFF
--- a/src/main/java/com/gamegoo/repository/chat/ChatRepositoryCustomImpl.java
+++ b/src/main/java/com/gamegoo/repository/chat/ChatRepositoryCustomImpl.java
@@ -7,6 +7,7 @@ import com.gamegoo.domain.chat.Chat;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -131,8 +132,9 @@ public class ChatRepositoryCustomImpl implements ChatRepositoryCustom {
     //--- BooleanExpression ---//
     private BooleanExpression createdAtGreaterThanLastViewDateSubQuery(Long memberChatroomId) {
         return chat.createdAt.gt(
-            JPAExpressions.select(memberChatroom.lastViewDate)
-                .from(memberChatroom)
+            JPAExpressions.select(
+                    memberChatroom.lastViewDate.coalesce(LocalDateTime.MIN)
+                ).from(memberChatroom)
                 .where(memberChatroom.id.eq(memberChatroomId))
         );
     }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
채팅방 목록 조회 API 버그 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- countUnreadChats 메소드의 lastViewDate 비교 쿼리 수정

## ⏳ 작업 내용
- [x] countUnreadChats 메소드의 lastViewDate 비교 쿼리 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
