### PR TITLE
[Fix/304] 회원용 게시판 글 조회 API - champion 정보 응답값 수정

### DIFF
--- a/src/main/java/com/gamegoo/service/board/BoardService.java
+++ b/src/main/java/com/gamegoo/service/board/BoardService.java
@@ -446,8 +446,8 @@ public class BoardService {
             mannerKeywordDTOs);
 
         List<MemberResponse.ChampionResponseDTO> championResponseDTOList = null;
-        if (member.getMemberChampionList() != null) {
-            championResponseDTOList = member.getMemberChampionList().stream()
+        if (poster.getMemberChampionList() != null) {
+            championResponseDTOList = poster.getMemberChampionList().stream()
                 .map(memberChampion -> MemberResponse.ChampionResponseDTO.builder()
                     .championId(memberChampion.getChampion().getId())
                     .championName(memberChampion.getChampion().getName())


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
회원용 게시판 글 조회 시 잘못된 챔피언 값이 들어가 이를 수정하였습니다.

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 회원용 게시판 글 조회 API - champion 정보 응답값 수정

## ⏳ 작업 내용
- [x] 회원용 게시판 글 조회 API - champion 정보 응답값 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
