### PR TITLE
[Feat/282] 매일 아침 7시 riot 정보 업데이트

### DIFF
--- a/src/main/java/com/gamegoo/apiPayload/exception/handler/MemberHandler.java
+++ b/src/main/java/com/gamegoo/apiPayload/exception/handler/MemberHandler.java
@@ -2,6 +2,9 @@ package com.gamegoo.apiPayload.exception.handler;
 
 import com.gamegoo.apiPayload.code.BaseErrorCode;
 import com.gamegoo.apiPayload.exception.GeneralException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
 
 public class MemberHandler extends GeneralException {
     public MemberHandler(BaseErrorCode code) {

--- a/src/main/java/com/gamegoo/domain/champion/MemberChampion.java
+++ b/src/main/java/com/gamegoo/domain/champion/MemberChampion.java
@@ -18,11 +18,11 @@ public class MemberChampion extends BaseDateTimeEntity {
     @Column(name = "member_champion_id", nullable = false)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "champion_id", nullable = false)
     private Champion champion;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 

--- a/src/main/java/com/gamegoo/domain/member/Member.java
+++ b/src/main/java/com/gamegoo/domain/member/Member.java
@@ -92,7 +92,7 @@ public class Member extends BaseDateTimeEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Board> boardList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private List<MemberChampion> memberChampionList = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)

--- a/src/main/java/com/gamegoo/repository/member/MemberRepository.java
+++ b/src/main/java/com/gamegoo/repository/member/MemberRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    List<Member> findAll();
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findById(Long id);

--- a/src/main/java/com/gamegoo/scheduler/SchedulerService.java
+++ b/src/main/java/com/gamegoo/scheduler/SchedulerService.java
@@ -108,6 +108,8 @@ public class SchedulerService {
 //    @Scheduled(cron = "0 0 7 * * *")
     @Scheduled(fixedRate = 5 * 60 * 1000) // 5 * 60초 주기로 실행
     public void updateAllUserRiotInformation(){
+        memberChampionRepository.deleteAllInBatch();
+
         memberRepository.findAll().forEach(member -> {
             String gameName = member.getGameName();
             String tag = member.getTag();
@@ -209,7 +211,6 @@ public class SchedulerService {
 
             memberRepository.save(member);
             System.out.println(member.getTier()+" "+member.getRank());
-            int i=0;
         });
 
     }

--- a/src/main/java/com/gamegoo/scheduler/SchedulerService.java
+++ b/src/main/java/com/gamegoo/scheduler/SchedulerService.java
@@ -21,16 +21,12 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import com.gamegoo.util.RiotUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 @Slf4j
@@ -192,10 +188,7 @@ public class SchedulerService {
                         .toList();
 
 
-
                 // 5. DB에 저장
-                System.out.println(member.getTier()+" "+member.getRank());
-
                 if (top3Champions != null) {
                     top3Champions
                             .forEach(championId -> {
@@ -210,14 +203,13 @@ public class SchedulerService {
                             });
                 }
 
-
             } catch (Exception e) {
                 log.warn("Riot 업데이트 - 라이엇 정보 연동에 문제 발생 : ",e);
             }
 
             memberRepository.save(member);
             System.out.println(member.getTier()+" "+member.getRank());
-
+            int i=0;
         });
 
     }

--- a/src/main/java/com/gamegoo/scheduler/SchedulerService.java
+++ b/src/main/java/com/gamegoo/scheduler/SchedulerService.java
@@ -1,19 +1,37 @@
 package com.gamegoo.scheduler;
 
+import com.gamegoo.apiPayload.code.status.ErrorStatus;
+import com.gamegoo.apiPayload.exception.handler.MemberHandler;
+import com.gamegoo.domain.champion.Champion;
+import com.gamegoo.domain.champion.MemberChampion;
 import com.gamegoo.domain.chat.Chat;
 import com.gamegoo.domain.matching.MatchingRecord;
 import com.gamegoo.domain.matching.MatchingStatus;
+import com.gamegoo.domain.member.Tier;
+import com.gamegoo.dto.member.RiotResponse;
 import com.gamegoo.repository.matching.MatchingRecordRepository;
+import com.gamegoo.repository.member.ChampionRepository;
+import com.gamegoo.repository.member.MemberChampionRepository;
+import com.gamegoo.repository.member.MemberRepository;
 import com.gamegoo.service.chat.ChatCommandService;
 import com.gamegoo.service.chat.ChatQueryService;
+import com.gamegoo.service.member.AuthService;
 import com.gamegoo.service.socket.SocketService;
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import com.gamegoo.util.RiotUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Hibernate;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
 
 @Slf4j
 @Service
@@ -21,11 +39,34 @@ import org.springframework.transaction.annotation.Transactional;
 public class SchedulerService {
 
     private final MatchingRecordRepository matchingRecordRepository;
+    private final MemberRepository memberRepository;
     private final ChatCommandService chatCommandService;
     private final ChatQueryService chatQueryService;
     private final SocketService socketService;
+    private final ChampionRepository championRepository;
+    private final MemberChampionRepository memberChampionRepository;
+
     private static final Long MANNER_MESSAGE_TIME = 60L; // 매칭 성공 n초 이후의 엔티티 조회함
     private static final String MANNER_SYSTEM_MESSAGE = "매칭은 어떠셨나요? 상대방의 매너를 평가해주세요!";
+
+    // RIOT
+    private final RestTemplate restTemplate;
+    @Value("${spring.riot.api.key}")
+    private String riotAPIKey;
+
+    private static final String RIOT_ACCOUNT_API_URL_TEMPLATE = "https://asia.api.riotgames.com/riot/account/v1/accounts/by-riot-id/%s/%s?api_key=%s";
+    private static final String RIOT_SUMMONER_API_URL_TEMPLATE = "https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-puuid/%s?api_key=%s";
+    private static final String RIOT_LEAGUE_API_URL_TEMPLATE = "https://kr.api.riotgames.com/lol/league/v4/entries/by-summoner/%s?api_key=%s";
+    private static final String RIOT_MATCH_API_URL_TEMPLATE = "https://asia.api.riotgames.com/lol/match/v5/matches/by-puuid/%s/ids?start=0&count=%s&api_key=%s";
+    private static final String RIOT_MATCH_INFO_API_URL_TEMPLATE = "https://asia.api.riotgames.com/lol/match/v5/matches/%s?api_key=%s";
+    private static final Map<String, Integer> romanToIntMap = new HashMap<>();
+
+    static {
+        romanToIntMap.put("I", 1);
+        romanToIntMap.put("II", 2);
+        romanToIntMap.put("III", 3);
+        romanToIntMap.put("IV", 4);
+    }
 
 
     /**
@@ -61,6 +102,141 @@ public class SchedulerService {
                 () -> log.info("Chatroom not found, member ID: {}, target member ID: {}",
                     matchingRecord.getMember().getId(), matchingRecord.getTargetMember().getId()));
         });
+
+    }
+
+    /**
+     * 07:00 모든 사용자 정보 업데이트
+     */
+//    @Transactional
+//    @Scheduled(cron = "0 0 7 * * *")
+    @Scheduled(fixedRate = 5 * 60 * 1000) // 5 * 60초 주기로 실행
+    public void updateAllUserRiotInformation(){
+        memberRepository.findAll().forEach(member -> {
+            String gameName = member.getGameName();
+            String tag = member.getTag();
+            System.out.println(gameName);
+            System.out.println(member.getTier()+" "+member.getRank());
+
+            try {
+                // 1. puuid 조회
+                String url = String.format(RIOT_ACCOUNT_API_URL_TEMPLATE, gameName, tag, riotAPIKey);
+                RiotResponse.RiotAccountDTO accountResponse = null;
+                accountResponse = restTemplate.getForObject(url, RiotResponse.RiotAccountDTO.class);
+                String puuid = accountResponse.getPuuid();
+
+                // 2. encryptedSummonerId 조회
+                String summonerUrl = String.format(RIOT_SUMMONER_API_URL_TEMPLATE, puuid, riotAPIKey);
+                RiotResponse.RiotSummonerDTO summonerResponse = null;
+                summonerResponse = restTemplate.getForObject(summonerUrl, RiotResponse.RiotSummonerDTO.class);
+                String encryptedSummonerId = summonerResponse.getId();
+
+                // 3. tier, rank, winrate 조회
+                //    (1) account id로 티어, 랭크, 불러오기
+                String leagueUrl = String.format(RIOT_LEAGUE_API_URL_TEMPLATE, encryptedSummonerId, riotAPIKey);
+                RiotResponse.RiotLeagueEntryDTO[] leagueEntries = restTemplate.getForObject(leagueUrl, RiotResponse.RiotLeagueEntryDTO[].class);
+
+                //    (2) tier, rank, gameCount 정보 저장
+                for (RiotResponse.RiotLeagueEntryDTO entry : leagueEntries) {
+                    // 솔랭일 경우에만 저장
+                    if ("RANKED_SOLO_5x5".equals(entry.getQueueType())) {
+                        int wins = entry.getWins();
+                        int losses = entry.getLosses();
+                        int gameCount = wins + losses;
+                        double winrate = (double) wins / (wins + losses);
+                        winrate = Math.round(winrate * 1000) / 10.0;
+                        Tier tier = Tier.valueOf(entry.getTier().toUpperCase());
+                        Integer rank = romanToIntMap.get(entry.getRank());
+
+                        // DB에 저장
+                        member.updateRiotDetails(tier, rank, winrate, gameCount);
+                        break;
+                    }
+                }
+
+                if (member.getTier() == null) {
+                    member.updateRiotDetails(Tier.UNRANKED,0,0.0,0);
+                }
+
+                // 4. 최근 플레이한 사용자 3개 불러오기
+                List<Integer> recentChampionIds = null;
+                int count = 20;
+
+                // 4-1. 최근 플레이한 챔피언 리스트 조회
+                while ((recentChampionIds == null || recentChampionIds.size() < 3) && count <= 100) {
+
+                    String matchUrl = String.format(RIOT_MATCH_API_URL_TEMPLATE, puuid, count, riotAPIKey);
+                    String[] matchIds = restTemplate.getForObject(matchUrl, String[].class);
+                    List<String> recentMatchIds = Arrays.asList(Objects.requireNonNull(matchIds));
+
+                    recentChampionIds = recentMatchIds.stream()
+                            .map(matchId -> getChampionIdFromMatch(matchId, gameName))
+                            .filter(championId -> championId < 1000)
+                            .toList();
+
+                    if (recentChampionIds.size() < 3) {
+                        count += 10; // count를 10 증가시켜서 다시 시도
+                    }
+                }
+
+                // 4-2. 해당 캐릭터 중 많이 사용한 캐릭터 세 개 저장하기
+                //      (1) 챔피언 사용 빈도 계산
+                Map<Integer, Long> championFrequency = recentChampionIds.stream()
+                        .collect(Collectors.groupingBy(championId -> championId, Collectors.counting()));
+
+                //      (2) 빈도를 기준으로 정렬하여 상위 3개의 챔피언 추출
+                List<Integer> top3Champions = championFrequency.entrySet().stream()
+                        .sorted(Map.Entry.<Integer, Long>comparingByValue().reversed())
+                        .limit(3)
+                        .map(Map.Entry::getKey)
+                        .toList();
+
+
+
+                // 5. DB에 저장
+                System.out.println(member.getTier()+" "+member.getRank());
+
+                if (top3Champions != null) {
+                    top3Champions
+                            .forEach(championId -> {
+                                Champion champion = championRepository.findById(Long.valueOf(championId))
+                                        .orElseThrow(() -> new MemberHandler(ErrorStatus.CHAMPION_NOT_FOUND));
+
+                                MemberChampion memberChampion = MemberChampion.builder()
+                                        .champion(champion)
+                                        .build();
+
+                                memberChampion.setMember(member);
+                            });
+                }
+
+
+            } catch (Exception e) {
+                log.warn("Riot 업데이트 - 라이엇 정보 연동에 문제 발생 : ",e);
+            }
+
+            memberRepository.save(member);
+            System.out.println(member.getTier()+" "+member.getRank());
+
+        });
+
+    }
+
+    public Integer getChampionIdFromMatch(String matchId, String gameName) {
+        // 매치 정보 가져오기
+        String matchInfoUrl = String.format(RIOT_MATCH_INFO_API_URL_TEMPLATE, matchId, riotAPIKey);
+        RiotResponse.MatchDTO matchResponse = restTemplate.getForObject(matchInfoUrl, RiotResponse.MatchDTO.class);
+
+
+        // 참가자 정보에서 gameName과 일치하는 사용자의 champion ID 찾기
+        return matchResponse.getInfo().getParticipants().stream()
+                .filter(participant -> gameName.equals(participant.getRiotIdGameName()))
+                .map(RiotResponse.ParticipantDTO::getChampionId)
+                .findFirst()
+                .orElseGet(() -> {
+                    log.info("Riot 업데이트 - 최근 선호 챔피언 값 중 id가 없는 챔피언이 있습니다.");
+                    return null;
+                });
 
     }
 }

--- a/src/main/java/com/gamegoo/scheduler/SchedulerService.java
+++ b/src/main/java/com/gamegoo/scheduler/SchedulerService.java
@@ -104,18 +104,19 @@ public class SchedulerService {
     /**
      * 07:00 모든 사용자 정보 업데이트
      */
-//    @Transactional
-//    @Scheduled(cron = "0 0 7 * * *")
-    @Scheduled(fixedRate = 5 * 60 * 1000) // 5 * 60초 주기로 실행
+    @Scheduled(cron = "0 0 7 * * *")
     public void updateAllUserRiotInformation(){
+        log.info("Riot 업데이트 - 시작");
+
         memberChampionRepository.deleteAllInBatch();
 
         memberRepository.findAll().forEach(member -> {
             String gameName = member.getGameName();
             String tag = member.getTag();
-            System.out.println(gameName);
-            System.out.println(member.getTier()+" "+member.getRank());
 
+            if(gameName.equals("SYSTEM")){
+                return;
+            }
             try {
                 // 1. puuid 조회
                 String url = String.format(RIOT_ACCOUNT_API_URL_TEMPLATE, gameName, tag, riotAPIKey);
@@ -210,9 +211,8 @@ public class SchedulerService {
             }
 
             memberRepository.save(member);
-            System.out.println(member.getTier()+" "+member.getRank());
         });
-
+        log.info("Riot 업데이트 - 완료");
     }
 
     public Integer getChampionIdFromMatch(String matchId, String gameName) {

--- a/src/main/java/com/gamegoo/service/member/AuthService.java
+++ b/src/main/java/com/gamegoo/service/member/AuthService.java
@@ -86,12 +86,29 @@ public class AuthService {
             .isAgree(isAgree)
             .build();
 
+        getRiotInformation(gameName, tag, puuid, member);
+
+        // 회원가입 완료된 사용자 정보 로그로 출력
+        log.info("회원가입 완료 - 이메일: {}, 프로필 이미지: {}, 소환사명: {}, 태그: {}, 티어: {}, 랭크: {}",
+            member.getEmail(), member.getProfileImage(), member.getGameName(), member.getTag(),
+            member.getTier(), member.getRank());
+
+        return member;
+    }
+
+    /**
+     * Riot 정보를 가져오는 메소드
+     * @param gameName
+     * @param tag
+     * @param puuid
+     * @param member
+     */
+    public void getRiotInformation(String gameName, String tag, String puuid, Member member) {
         // 2. tier, rank, winrate 저장
         String encryptedSummonerId = riotUtil.getSummonerId(puuid);
         riotUtil.addTierRankWinRate(member, gameName, encryptedSummonerId, tag);
 
         memberRepository.save(member);
-
 
         // 최근 선호 챔피언 3개 리스트 조회
         List<Integer> top3Champions = null;
@@ -118,13 +135,6 @@ public class AuthService {
                     });
 
         }
-
-        // 회원가입 완료된 사용자 정보 로그로 출력
-        log.info("회원가입 완료 - 이메일: {}, 프로필 이미지: {}, 소환사명: {}, 태그: {}, 티어: {}, 랭크: {}",
-            member.getEmail(), member.getProfileImage(), member.getGameName(), member.getTag(),
-            member.getTier(), member.getRank());
-
-        return member;
     }
 
     /**

--- a/src/main/java/com/gamegoo/util/RiotUtil.java
+++ b/src/main/java/com/gamegoo/util/RiotUtil.java
@@ -13,10 +13,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import javax.transaction.Transactional;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Component
@@ -203,11 +200,7 @@ public class RiotUtil {
         String matchUrl = String.format(RIOT_MATCH_API_URL_TEMPLATE, puuid, count, riotAPIKey);
         String[] matchIds = restTemplate.getForObject(matchUrl, String[].class);
 
-        if (matchIds == null || matchIds.length == 0) {
-
-        }
-
-        return Arrays.asList(matchIds);
+        return Arrays.asList(Objects.requireNonNull(matchIds));
     }
 
 


### PR DESCRIPTION
## 🚀 개요
07:00 에 Riot 정보 업데이트하는 스케줄러 개발

## 🔍 변경사항
- memberRepository memberChampion 테이블 fetch="EAGER" 옵션 변경
- scheduler에 로직 추가

## ⏳ 작업 내용
- [x] scheduler 로직 추가

### 📝 논의사항
scheduler에 transaction 어노테이션이 들어가면 DB에 업데이트가 안됩니다. 아마 중간에 데이터값이 뭔가 요상하게 바뀌어서 rollback이 이루어지는 것 같아요. 이 부분은 나중에 Riot 전체 리팩토링하면서 함께 변경해야할 것 같습니다.