### PR TITLE
🐛[Fix] Riot 소환사 명 없을 경우 인증 안되도록 확인

### DIFF
--- a/src/main/java/com/gamegoo/service/member/RiotService.java
+++ b/src/main/java/com/gamegoo/service/member/RiotService.java
@@ -29,6 +29,14 @@ public class RiotService {
             throw new MemberHandler(ErrorStatus.RIOT_NOT_FOUND);
         }
 
+        String summonerId = riotUtil.getSummonerId(riotPuuid);
+
+        if (summonerId == null) {
+            throw new MemberHandler(ErrorStatus.RIOT_NOT_FOUND);
+        }
+
+
+
         return riotPuuid;
     }
 


### PR DESCRIPTION
## 🚀 개요
Riot 소환사 명 없을 경우 인증 안되도록 확인

## 🔍 변경사항
- Riot 인증 로직 puuid 뿐만 아니라 summonerId도 받아올 수 있는지 확인하도록 변경

## ⏳ 작업 내용
- [x] RiotService 로직 수정

### 📝 논의사항
