### PR TITLE
[Fix/315] 보안 관련 비밀번호, 다른회원 프로필 조회 수정

### DIFF
--- a/src/main/java/com/gamegoo/controller/member/AuthController.java
+++ b/src/main/java/com/gamegoo/controller/member/AuthController.java
@@ -46,7 +46,7 @@ public class AuthController {
         String email = emailRequestDTO.getEmail();
 
         authService.verifyEmailforNewUser(email);
-        authService.sendEmail(email);
+        authService.sendEmailVerification(email);
         return ApiResponse.onSuccess("인증 이메일을 발송했습니다.");
     }
 
@@ -55,7 +55,7 @@ public class AuthController {
     public ApiResponse<String> sendEmail(
             @Valid @RequestBody MemberRequest.EmailRequestDTO emailRequestDTO) {
         String email = emailRequestDTO.getEmail();
-        authService.sendEmail(email);
+        authService.sendEmailVerification(email);
         return ApiResponse.onSuccess("인증 이메일을 발송했습니다.");
     }
 
@@ -68,7 +68,7 @@ public class AuthController {
         // DB에 없는 사용자일 경우 에러 발생
         authService.verifyEmailforExistUser(email);
 
-        authService.sendEmail(email);
+        authService.sendEmailVerification(email);
         return ApiResponse.onSuccess("인증 이메일을 발송했습니다.");
     }
 

--- a/src/main/java/com/gamegoo/controller/member/PasswordController.java
+++ b/src/main/java/com/gamegoo/controller/member/PasswordController.java
@@ -55,7 +55,7 @@ public class PasswordController {
     public ApiResponse<String> resetPassword(
             @Valid @RequestBody MemberRequest.PasswordRequestDTO passwordRequestDTO) {
 
-        passwordService.updatePasswordWithEmail(passwordRequestDTO.getEmail(), passwordRequestDTO.getOldPassword(), passwordRequestDTO.getNewPassword());
+        passwordService.updatePasswordWithEmail(passwordRequestDTO.getEmail());
 
         return ApiResponse.onSuccess("비밀번호 재설정을 완료했습니다.");
     }

--- a/src/main/java/com/gamegoo/controller/member/PasswordController.java
+++ b/src/main/java/com/gamegoo/controller/member/PasswordController.java
@@ -27,11 +27,11 @@ public class PasswordController {
     @PostMapping("/check")
     @Operation(summary = "JWT 토큰이 필요한 비밀번호 확인 API 입니다.", description = "API for checking password with JWT")
     public ApiResponse<String> checkPasswordWithJWT(
-            @Valid @RequestBody MemberRequest.PasswordRequestJWTDTO passwordRequestDTO) {
+            @Valid @RequestBody MemberRequest.PasswordCheckRequestDTO passwordCheckRequestDTO) {
         Long currentUserId = JWTUtil.getCurrentUserId(); //헤더에 있는 jwt 토큰에서 id를 가져오는 코드
 
         boolean isPasswordValid = passwordService.checkPasswordById(currentUserId,
-                passwordRequestDTO.getPassword()); //request body에 있는 password와 currentUserId를 전달
+                passwordCheckRequestDTO.getPassword()); //request body에 있는 password와 currentUserId를 전달
 
         if (isPasswordValid) {
             return ApiResponse.onSuccess("비밀번호가 일치합니다.");
@@ -45,7 +45,7 @@ public class PasswordController {
     public ApiResponse<String> resetPasswordWithJWT(
             @Valid @RequestBody MemberRequest.PasswordRequestJWTDTO passwordRequestDTO) {
         Long currentUserId = JWTUtil.getCurrentUserId();
-        passwordService.updatePassword(currentUserId, passwordRequestDTO.getPassword());
+        passwordService.updatePassword(currentUserId, passwordRequestDTO.getOldPassword(), passwordRequestDTO.getNewPassword());
 
         return ApiResponse.onSuccess("비밀번호 재설정을 완료했습니다.");
     }
@@ -55,7 +55,7 @@ public class PasswordController {
     public ApiResponse<String> resetPassword(
             @Valid @RequestBody MemberRequest.PasswordRequestDTO passwordRequestDTO) {
 
-        passwordService.updatePasswordWithEmail(passwordRequestDTO.getEmail(), passwordRequestDTO.getPassword());
+        passwordService.updatePasswordWithEmail(passwordRequestDTO.getEmail(), passwordRequestDTO.getOldPassword(), passwordRequestDTO.getNewPassword());
 
         return ApiResponse.onSuccess("비밀번호 재설정을 완료했습니다.");
     }

--- a/src/main/java/com/gamegoo/converter/MemberConverter.java
+++ b/src/main/java/com/gamegoo/converter/MemberConverter.java
@@ -150,7 +150,6 @@ public class MemberConverter {
         return MemberResponse.memberProfileDTO.builder()
             .id(targetMember.getId())
             .mike(targetMember.getMike())
-            .email(targetMember.getEmail())
             .gameName(targetMember.getGameName())
             .tag(targetMember.getTag())
             .tier(targetMember.getTier())

--- a/src/main/java/com/gamegoo/dto/member/MemberRequest.java
+++ b/src/main/java/com/gamegoo/dto/member/MemberRequest.java
@@ -55,6 +55,15 @@ public class MemberRequest {
 
     @Getter
     public static class PasswordRequestJWTDTO {
+        @NotBlank(message = "newPassword는 비워둘 수 없습니다.")
+        String newPassword;
+        @NotBlank(message = "oldPassword는 비워둘 수 없습니다.")
+        String oldPassword;
+
+    }
+
+    @Getter
+    public static class PasswordCheckRequestDTO {
         @NotBlank(message = "password는 비워둘 수 없습니다.")
         String password;
 
@@ -65,8 +74,10 @@ public class MemberRequest {
         @Email(message = "Email 형식이 올바르지 않습니다.")
         @NotBlank(message = "Email은 비워둘 수 없습니다.")
         String email;
-        @NotBlank(message = "password는 비워둘 수 없습니다.")
-        String password;
+        @NotBlank(message = "newPassword는 비워둘 수 없습니다.")
+        String newPassword;
+        @NotBlank(message = "oldPassword는 비워둘 수 없습니다.")
+        String oldPassword;
 
     }
 

--- a/src/main/java/com/gamegoo/dto/member/MemberRequest.java
+++ b/src/main/java/com/gamegoo/dto/member/MemberRequest.java
@@ -74,10 +74,6 @@ public class MemberRequest {
         @Email(message = "Email 형식이 올바르지 않습니다.")
         @NotBlank(message = "Email은 비워둘 수 없습니다.")
         String email;
-        @NotBlank(message = "newPassword는 비워둘 수 없습니다.")
-        String newPassword;
-        @NotBlank(message = "oldPassword는 비워둘 수 없습니다.")
-        String oldPassword;
 
     }
 

--- a/src/main/java/com/gamegoo/dto/member/MemberResponse.java
+++ b/src/main/java/com/gamegoo/dto/member/MemberResponse.java
@@ -142,7 +142,6 @@ public class MemberResponse {
         Long id;
         Integer profileImg;
         Boolean mike;
-        String email;
         String gameName;
         String tag;
         Tier tier;

--- a/src/main/java/com/gamegoo/service/member/AuthService.java
+++ b/src/main/java/com/gamegoo/service/member/AuthService.java
@@ -175,10 +175,10 @@ public class AuthService {
      * @param email
      */
     @Transactional
-    public void sendEmail(String email) {
+    public void sendEmailVerification(String email) {
 
         // 랜덤 코드 생성하기
-        String certificationNumber = CodeGeneratorUtil.generateRandomCode();
+        String certificationNumber = CodeGeneratorUtil.generateEmailRandomCode();
 
         // 메일 전송하기
         sendEmailInternal(email, certificationNumber);
@@ -256,7 +256,7 @@ public class AuthService {
      * @param email
      * @param certificationNumber
      */
-    private void sendEmailInternal(String email, String certificationNumber) {
+    public void sendEmailInternal(String email, String certificationNumber) {
         try {
             log.info("Starting email send process for email: {}, certificationNumber: {}", email,
                 certificationNumber);

--- a/src/main/java/com/gamegoo/service/member/PasswordService.java
+++ b/src/main/java/com/gamegoo/service/member/PasswordService.java
@@ -34,14 +34,22 @@ public class PasswordService {
      * @param userId
      * @param newPassword
      */
-    public void updatePassword(Long userId, String newPassword) {
+    public void updatePassword(Long userId, String oldPassword, String newPassword) {
         // jwt 토큰으로 멤버 찾기
         Member member = memberRepository.findById(userId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-        // 비밀번호 재설정
-        member.updatePassword(bCryptPasswordEncoder.encode(newPassword));
-        memberRepository.save(member);
+        boolean matches = bCryptPasswordEncoder.matches(oldPassword, member.getPassword());
+
+        if (matches) {
+            // 비밀번호 재설정
+            member.updatePassword(bCryptPasswordEncoder.encode(newPassword));
+            memberRepository.save(member);
+        }else{
+            throw new MemberHandler(ErrorStatus.PASSWORD_INVALID);
+        }
+
+
     }
 
     /**
@@ -50,14 +58,19 @@ public class PasswordService {
      * @param email
      * @param newPassword
      */
-    public void updatePasswordWithEmail(String email, String newPassword) {
+    public void updatePasswordWithEmail(String email, String oldPassword, String newPassword) {
         // jwt 토큰으로 멤버 찾기
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-        // 비밀번호 재설정
-        member.updatePassword(bCryptPasswordEncoder.encode(newPassword));
-        memberRepository.save(member);
+
+        if (bCryptPasswordEncoder.matches(oldPassword,member.getPassword())) {
+            // 비밀번호 재설정
+            member.updatePassword(bCryptPasswordEncoder.encode(newPassword));
+            memberRepository.save(member);
+        }else{
+            throw new MemberHandler(ErrorStatus.PASSWORD_INVALID);
+        }
     }
 
 }

--- a/src/main/java/com/gamegoo/service/member/PasswordService.java
+++ b/src/main/java/com/gamegoo/service/member/PasswordService.java
@@ -4,16 +4,26 @@ import com.gamegoo.apiPayload.code.status.ErrorStatus;
 import com.gamegoo.apiPayload.exception.handler.MemberHandler;
 import com.gamegoo.domain.member.Member;
 import com.gamegoo.repository.member.MemberRepository;
+import com.gamegoo.util.CodeGeneratorUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PasswordService {
 
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final JavaMailSender javaMailSender;
+
 
     /**
      * 비밀번호가 맞는지 확인
@@ -29,7 +39,7 @@ public class PasswordService {
     }
 
     /**
-     * 비밀번호 수정
+     * 비밀번호 수정 (로그인O)
      *
      * @param userId
      * @param newPassword
@@ -49,28 +59,204 @@ public class PasswordService {
             throw new MemberHandler(ErrorStatus.PASSWORD_INVALID);
         }
 
-
     }
 
     /**
-     * 비밀번호 수정
+     * 비밀번호 수정 (로그인X)
      *
      * @param email
-     * @param newPassword
      */
-    public void updatePasswordWithEmail(String email, String oldPassword, String newPassword) {
-        // jwt 토큰으로 멤버 찾기
+    public void updatePasswordWithEmail(String email) {
+        // email으로 멤버 찾기
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
+        // 랜덤 임시 비밀번호 생성
+        String tempPassword = CodeGeneratorUtil.generatePasswordRandomCode();
 
-        if (bCryptPasswordEncoder.matches(oldPassword,member.getPassword())) {
+        // 이메일 전송
+        sendEmailInternal(email,tempPassword);
+
             // 비밀번호 재설정
-            member.updatePassword(bCryptPasswordEncoder.encode(newPassword));
+            member.updatePassword(bCryptPasswordEncoder.encode(tempPassword));
             memberRepository.save(member);
-        }else{
-            throw new MemberHandler(ErrorStatus.PASSWORD_INVALID);
+    }
+
+    /**
+     * Gmail 발송
+     *
+     * @param email
+     * @param tempPassword
+     */
+    public void sendEmailInternal(String email, String tempPassword) {
+        try {
+            log.info("Starting email send process for email: {}, certificationNumber: {}", email,
+                    tempPassword);
+
+            MimeMessage message = javaMailSender.createMimeMessage();
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(message, true);
+
+            String htmlContent = getTempPasswordMessage(tempPassword);
+
+            mimeMessageHelper.setTo(email);
+            mimeMessageHelper.setSubject("GameGoo 임시 비밀번호 발급");
+            mimeMessageHelper.setText(htmlContent, true);
+            log.debug("Prepared email message for email: {}", email);
+
+            javaMailSender.send(message);
+            log.info("Email sent successfully to email: {}", email);
+
+
+        } catch (MessagingException e) {
+            log.error("Failed to send email to email: {}, certificationNumber: {}, error: {}",
+                    email, tempPassword, e.getMessage());
+
+            throw new MemberHandler(ErrorStatus.EMAIL_SEND_ERROR);
         }
+    }
+
+    /**
+     * 메일 내용 편집
+     *
+     * @param tempPassword
+     * @return
+     */
+    private String getTempPasswordMessage(String tempPassword) {
+        String certificationMessage = ""
+                + "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n"
+                +
+                "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n" +
+                "  <head>\n" +
+                "    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\n" +
+                "    <title>Gamegoo 임시 비밀번호 발급</title>\n" +
+                "    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" />\n" +
+                "  </head>\n" +
+                "  <body>\n" +
+                "    <table\n" +
+                "      style=\"\n" +
+                "        width: 628px;\n" +
+                "        box-sizing: border-box;\n" +
+                "        border-collapse: collapse;\n" +
+                "        background-color: #ffffff;\n" +
+                "        border: 1px solid #c0c0c0;\n" +
+                "        text-align: left;\n" +
+                "        margin: 0 auto;\n" +
+                "      \"\n" +
+                "    >\n" +
+                "      <tbody>\n" +
+                "        <tr>\n" +
+                "          <td>\n" +
+                "            <table\n" +
+                "              cellpadding=\"0\"\n" +
+                "              cellspacing=\"0\"\n" +
+                "              style=\"width: 628px; height: 521px; padding: 53px 62px 42px 62px\"\n" +
+                "            >\n" +
+                "              <tbody>\n" +
+                "                <tr>\n" +
+                "                  <td style=\"padding-bottom: 11.61px\">\n" +
+                "                    <img\n" +
+                "                      src=\"https://ifh.cc/g/BY3XG2.png\"\n" +
+                "                      style=\"display: block\"\n" +
+                "                      width=\"137\"\n" +
+                "                      height=\"24\"\n" +
+                "                      alt=\"Gamegoo\"\n" +
+                "                    />\n" +
+                "                  </td>\n" +
+                "                </tr>\n" +
+                "                <tr>\n" +
+                "                  <td style=\"padding-top: 20px\">\n" +
+                "                    <span\n" +
+                "                      style=\"\n" +
+                "                        color: #2d2d2d;\n" +
+                "                        font-family: Pretendard;\n" +
+                "                        font-size: 25px;\n" +
+                "                        font-style: normal;\n" +
+                "                        font-weight: 400;\n" +
+                "                        line-height: 150%;\n" +
+                "                      \"\n" +
+                "                    >\n" +
+                "                      임시 비밀번호를 확인해주세요\n" +
+                "                    </span>\n" +
+                "                  </td>\n" +
+                "                </tr>\n" +
+                "                <tr>\n" +
+                "                  <td style=\"padding-top: 38px\">\n" +
+                "                    <span\n" +
+                "                      style=\"\n" +
+                "                        color: #5a42ee;\n" +
+                "                        color: #2d2d2d;\n" +
+                "                        font-size: 32px;\n" +
+                "                        font-style: normal;\n" +
+                "                        font-weight: 700;\n" +
+                "                        line-height: 150%;\n" +
+                "                        margin-bottom: 30px;\n" +
+                "                      \"\n" +
+                "                    >\n" +
+                tempPassword +
+                "                    </span>\n" +
+                "                  </td>\n" +
+                "                </tr>\n" +
+                "                <tr>\n" +
+                "                  <td style=\"padding-top: 30px\">\n" +
+                "                    <span\n" +
+                "                      style=\"\n" +
+                "                        color: #2d2d2d;\n" +
+                "                        font-family: Pretendard;\n" +
+                "                        font-size: 18px;\n" +
+                "                        font-style: normal;\n" +
+                "                        font-weight: 400;\n" +
+                "                        line-height: 150%;\n" +
+                "                      \"\n" +
+                "                    >\n" +
+                "                      임시 비밀번호가 발급되었습니다. \n" +
+                "                      감사합니다.\n" +
+                "                    </span>\n" +
+                "                  </td>\n" +
+                "                </tr>\n" +
+                "              </tbody>\n" +
+                "            </table>\n" +
+                "            <table\n" +
+                "              cellpadding=\"0\"\n" +
+                "              cellspacing=\"0\"\n" +
+                "              style=\"\n" +
+                "                width: 628px;\n" +
+                "                height: 292px;\n" +
+                "                padding: 37px 0px 153px 62px;\n" +
+                "                background: #f7f7f9;\n" +
+                "              \"\n" +
+                "            >\n" +
+                "              <tbody>\n" +
+                "                <tr>\n" +
+                "                  <td>\n" +
+                "                    <span\n" +
+                "                      style=\"\n" +
+                "                        color: #606060;\n" +
+                "                        font-family: Pretendard;\n" +
+                "                        font-size: 11px;\n" +
+                "                        font-style: normal;\n" +
+                "                        font-weight: 500;\n" +
+                "                        line-height: 150%;\n" +
+                "                      \"\n" +
+                "                    >\n" +
+                "                      본 메일은 발신 전용으로 회신되지 않습니다.<br />\n" +
+                "                      궁금하신 점은 겜구 이메일이나 카카오 채널을 통해\n" +
+                "                      문의하시기 바랍니다.<br /><br />\n" +
+                "                      email: gamegoo0707@gmail.com<br />\n" +
+                "                      kakao: https://pf.kakao.com/_Rrxiqn<br />\n" +
+                "                      copyright 2024. GameGoo All Rights Reserved.<br />\n" +
+                "                    </span>\n" +
+                "                  </td>\n" +
+                "                </tr>\n" +
+                "              </tbody>\n" +
+                "            </table>\n" +
+                "          </td>\n" +
+                "        </tr>\n" +
+                "      </tbody>\n" +
+                "    </table>\n" +
+                "  </body>\n" +
+                "</html>\n";
+
+        return certificationMessage;
     }
 
 }

--- a/src/main/java/com/gamegoo/util/CodeGeneratorUtil.java
+++ b/src/main/java/com/gamegoo/util/CodeGeneratorUtil.java
@@ -4,24 +4,58 @@ import java.security.SecureRandom;
 
 public class CodeGeneratorUtil {
 
-    private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    private static final String UPPER_CASE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private static final String LOWER_CASE = "abcdefghijklmnopqrstuvwxyz";
+    private static final String DIGITS = "0123456789";
+    private static final String ALL_CHARACTERS = UPPER_CASE + LOWER_CASE + DIGITS;
     private static final SecureRandom random = new SecureRandom();
-    private static final int CODE_LENGTH = 5;
+    private static final int EMAIL_CODE_LENGTH = 5;
+    private static final int PASSWORD_CODE_LENGTH = 12;
 
     /**
      * 이메일 인증에 사용하는 메소드 : 랜덤 코드 만들기
      *
      * @return
      */
-    public static String generateRandomCode() {
-        StringBuilder code = new StringBuilder(CODE_LENGTH);
-        for (int i = 0; i < CODE_LENGTH; i++) {
-            int index = random.nextInt(CHARACTERS.length());
-            code.append(CHARACTERS.charAt(index));
+    public static String generateEmailRandomCode() {
+        StringBuilder code = new StringBuilder(EMAIL_CODE_LENGTH);
+        for (int i = 0; i < EMAIL_CODE_LENGTH; i++) {
+            int index = random.nextInt(UPPER_CASE.length() + DIGITS.length());
+            code.append(UPPER_CASE.charAt(index % UPPER_CASE.length()));
         }
-        System.out.println(code);
         return code.toString();
     }
 
+    /**
+     * 비밀번호 재설정하는 랜덤 코드 생성
+     * @return
+     */
+    public static String generatePasswordRandomCode(){
+        StringBuilder code = new StringBuilder(PASSWORD_CODE_LENGTH);
 
+        // 최소한 하나의 대문자, 소문자, 숫자, 특수문자를 포함하도록 함
+        code.append(UPPER_CASE.charAt(random.nextInt(UPPER_CASE.length())));
+        code.append(LOWER_CASE.charAt(random.nextInt(LOWER_CASE.length())));
+        code.append(DIGITS.charAt(random.nextInt(DIGITS.length())));
+
+        // 나머지 길이를 랜덤한 모든 문자로 채움
+        for (int i = 4; i < PASSWORD_CODE_LENGTH; i++) {
+            int index = random.nextInt(ALL_CHARACTERS.length());
+            code.append(ALL_CHARACTERS.charAt(index));
+        }
+
+        // 생성된 비밀번호를 섞어서 반환
+        return shuffleString(code.toString());
+    }
+
+    private static String shuffleString(String input) {
+        char[] characters = input.toCharArray();
+        for (int i = 0; i < characters.length; i++) {
+            int randomIndex = random.nextInt(characters.length);
+            char temp = characters[i];
+            characters[i] = characters[randomIndex];
+            characters[randomIndex] = temp;
+        }
+        return new String(characters);
+    }
 }


### PR DESCRIPTION
## 🚀 개요
보안 관련 수정사항

## 🔍 변경사항
- 비밀번호 변경할 때 이전 비밀번호를 알 수 있도록 수정
- 다른 사람 조회 api에서 Email 안보이도록 수정

## ⏳ 작업 내용
- 비밀번호 변경할 때 이전 비밀번호를 알 수 있도록 수정
- 다른 사람 조회 api에서 Email 안보이도록 수정

### 📝 논의사항
메일로 인증확인 받아서 비밀번호를 재설정할 경우에는 어떻게 해야할까요................?
그럴때는 사용자도 이전 비밀번호를 모르고, 프론트도 당연히 이전 비밀번호를 모를 것 같아서요ㅠ
이 부분은 차라리 이전 비밀번호 대신에 확인 코드를 받는게 더 좋을 것 같다는 생각이 듭니다..