### PR TITLE
🐛[Fix] 비밀번호 재설정을 위한 인증코드 발송 및 검증, 새로운 비밀번호로 수정

### DIFF
--- a/src/main/java/com/gamegoo/controller/member/AuthController.java
+++ b/src/main/java/com/gamegoo/controller/member/AuthController.java
@@ -78,7 +78,7 @@ public class AuthController {
             @Valid @RequestBody MemberRequest.EmailCodeRequestDTO emailCodeRequestDTO) {
         String email = emailCodeRequestDTO.getEmail();
         String code = emailCodeRequestDTO.getCode();
-        authService.verifyEmail(email, code);
+        authService.verifyCode(email, code);
         return ApiResponse.onSuccess("인증코드 검증에 성공했습니다.");
     }
 

--- a/src/main/java/com/gamegoo/controller/member/PasswordController.java
+++ b/src/main/java/com/gamegoo/controller/member/PasswordController.java
@@ -4,6 +4,7 @@ import com.gamegoo.apiPayload.ApiResponse;
 import com.gamegoo.apiPayload.code.status.ErrorStatus;
 import com.gamegoo.apiPayload.exception.handler.MemberHandler;
 import com.gamegoo.dto.member.MemberRequest;
+import com.gamegoo.service.member.AuthService;
 import com.gamegoo.service.member.PasswordService;
 import com.gamegoo.util.JWTUtil;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,6 +24,7 @@ import javax.validation.Valid;
 public class PasswordController {
 
     private final PasswordService passwordService;
+    private final AuthService authService;
 
     @PostMapping("/check")
     @Operation(summary = "JWT 토큰이 필요한 비밀번호 확인 API 입니다.", description = "API for checking password with JWT")
@@ -45,7 +47,7 @@ public class PasswordController {
     public ApiResponse<String> resetPasswordWithJWT(
             @Valid @RequestBody MemberRequest.PasswordRequestJWTDTO passwordRequestDTO) {
         Long currentUserId = JWTUtil.getCurrentUserId();
-        passwordService.updatePassword(currentUserId, passwordRequestDTO.getOldPassword(), passwordRequestDTO.getNewPassword());
+        passwordService.updatePasswordById(currentUserId, passwordRequestDTO.getOldPassword(), passwordRequestDTO.getNewPassword());
 
         return ApiResponse.onSuccess("비밀번호 재설정을 완료했습니다.");
     }
@@ -54,8 +56,16 @@ public class PasswordController {
     @Operation(summary = "비밀번호 재설정 API 입니다.", description = "API for reseting password")
     public ApiResponse<String> resetPassword(
             @Valid @RequestBody MemberRequest.PasswordRequestDTO passwordRequestDTO) {
+        // dto
+        String email = passwordRequestDTO.getEmail();
+        String verifyCode = passwordRequestDTO.getVerifyCode();
+        String newPassword = passwordRequestDTO.getNewPassword();
 
-        passwordService.updatePasswordWithEmail(passwordRequestDTO.getEmail());
+        // 인증코드 검증
+        authService.verifyCode(email,verifyCode);
+
+        // 비밀번호 재설정
+        passwordService.updatePasswordWithEmail(email, newPassword);
 
         return ApiResponse.onSuccess("비밀번호 재설정을 완료했습니다.");
     }

--- a/src/main/java/com/gamegoo/dto/member/MemberRequest.java
+++ b/src/main/java/com/gamegoo/dto/member/MemberRequest.java
@@ -75,6 +75,12 @@ public class MemberRequest {
         @NotBlank(message = "Email은 비워둘 수 없습니다.")
         String email;
 
+        @NotBlank(message = "newPassword는 비워둘 수 없습니다.")
+        String newPassword;
+
+        @NotBlank(message = "verifyCode는 비워둘 수 없습니다.")
+        String verifyCode;
+
     }
 
 

--- a/src/main/java/com/gamegoo/service/member/AuthService.java
+++ b/src/main/java/com/gamegoo/service/member/AuthService.java
@@ -225,7 +225,7 @@ public class AuthService {
      * @param email
      * @param code
      */
-    public void verifyEmail(String email, String code) {
+    public void verifyCode(String email, String code) {
         // 이메일로 보낸 인증 코드 중 가장 최근의 데이터를 불러옴
         EmailVerifyRecord emailVerifyRecord = emailVerifyRecordRepository.findByEmailOrderByUpdatedAtDesc(
                 email, PageRequest.of(0, 1))

--- a/src/main/java/com/gamegoo/service/member/PasswordService.java
+++ b/src/main/java/com/gamegoo/service/member/PasswordService.java
@@ -4,7 +4,6 @@ import com.gamegoo.apiPayload.code.status.ErrorStatus;
 import com.gamegoo.apiPayload.exception.handler.MemberHandler;
 import com.gamegoo.domain.member.Member;
 import com.gamegoo.repository.member.MemberRepository;
-import com.gamegoo.util.CodeGeneratorUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -44,7 +43,7 @@ public class PasswordService {
      * @param userId
      * @param newPassword
      */
-    public void updatePassword(Long userId, String oldPassword, String newPassword) {
+    public void updatePasswordById(Long userId, String oldPassword, String newPassword) {
         // jwt 토큰으로 멤버 찾기
         Member member = memberRepository.findById(userId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
@@ -66,20 +65,15 @@ public class PasswordService {
      *
      * @param email
      */
-    public void updatePasswordWithEmail(String email) {
+    public void updatePasswordWithEmail(String email, String newPassword) {
         // email으로 멤버 찾기
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-        // 랜덤 임시 비밀번호 생성
-        String tempPassword = CodeGeneratorUtil.generatePasswordRandomCode();
+        // 비밀번호 재설정
+        member.updatePassword(bCryptPasswordEncoder.encode(newPassword));
+        memberRepository.save(member);
 
-        // 이메일 전송
-        sendEmailInternal(email,tempPassword);
-
-            // 비밀번호 재설정
-            member.updatePassword(bCryptPasswordEncoder.encode(tempPassword));
-            memberRepository.save(member);
     }
 
     /**


### PR DESCRIPTION
## 🚀 개요
비밀번호 변경 로직 원상복귀

## 🔍 변경사항
- verifyEmail -> verifyCode authService 이름 변경
- passwordDTO 변경
- password 변경하는 service 변경

## ⏳ 작업 내용
- [x] 비밀번호 인증코드가 있을 경우에만 변경할 수 있도록 변경

### 📝 논의사항
